### PR TITLE
TAPI 2.0 Bug Fixes

### DIFF
--- a/SWAGGER/tapi-common.swagger
+++ b/SWAGGER/tapi-common.swagger
@@ -1349,7 +1349,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }

--- a/SWAGGER/tapi-common.swagger
+++ b/SWAGGER/tapi-common.swagger
@@ -27,7 +27,7 @@
                         "in": "body",
                         "name": "context",
                         "schema": {
-                            "$ref": "#/definitions/context"
+                            "$ref": "#/definitions/tapi-context"
                         },
                         "description": "contextbody object",
                         "required": true
@@ -57,7 +57,7 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/context"
+                            "$ref": "#/definitions/tapi-context"
                         }
                     },
                     "400": {
@@ -80,7 +80,7 @@
                         "in": "body",
                         "name": "context",
                         "schema": {
-                            "$ref": "#/definitions/context"
+                            "$ref": "#/definitions/tapi-context"
                         },
                         "description": "contextbody object",
                         "required": true
@@ -1301,7 +1301,7 @@
                 }
             }
         },
-        "context": {
+        "tapi-context": {
             "allOf": [
                 {
                     "$ref": "#/definitions/global-class"

--- a/SWAGGER/tapi-connectivity.swagger
+++ b/SWAGGER/tapi-connectivity.swagger
@@ -10014,7 +10014,7 @@
                         "in": "body",
                         "name": "capacity",
                         "schema": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         },
                         "description": "capacitybody object",
                         "required": true
@@ -10059,7 +10059,7 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         }
                     },
                     "400": {
@@ -10096,7 +10096,7 @@
                         "in": "body",
                         "name": "capacity",
                         "schema": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         },
                         "description": "capacitybody object",
                         "required": true
@@ -10147,11 +10147,11 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_total-potential-capacity",
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-size/": {
+            "post": {
+                "summary": "Create total-size by ID",
+                "description": "Create operation of resource: total-size",
+                "operationId": "create_context_connectivity-service_end-point_capacity_total-size_total-size_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -10172,27 +10172,31 @@
                         "description": "ID of local_id",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "total-size",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/total-size/": {
+            },
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_total-size_total-size",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -10227,13 +10231,11 @@
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+            },
+            "put": {
+                "summary": "Update total-size by ID",
+                "description": "Update operation of resource: total-size",
+                "operationId": "update_context_connectivity-service_end-point_capacity_total-size_total-size_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -10254,256 +10256,56 @@
                         "description": "ID of local_id",
                         "required": true,
                         "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
                     },
                     {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
+                        "in": "body",
+                        "name": "total-size",
                         "schema": {
                             "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
                             "$ref": "#/definitions/capacity-value"
-                        }
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete total-size by ID",
+                "description": "Delete operation of resource: total-size",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -10511,11 +10313,55 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/": {
+            "post": {
+                "summary": "Create bandwidth-profile by ID",
+                "description": "Create operation of resource: bandwidth-profile",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -10549,13 +10395,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update bandwidth-profile by ID",
+                "description": "Update operation of resource: bandwidth-profile",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete bandwidth-profile by ID",
+                "description": "Delete operation of resource: bandwidth-profile",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/committed-information-rate/": {
+            "post": {
+                "summary": "Create committed-information-rate by ID",
+                "description": "Create operation of resource: committed-information-rate",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -10589,13 +10558,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-information-rate by ID",
+                "description": "Update operation of resource: committed-information-rate",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-information-rate by ID",
+                "description": "Delete operation of resource: committed-information-rate",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/committed-burst-size/": {
+            "post": {
+                "summary": "Create committed-burst-size by ID",
+                "description": "Create operation of resource: committed-burst-size",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -10629,13 +10721,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-burst-size by ID",
+                "description": "Update operation of resource: committed-burst-size",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-burst-size by ID",
+                "description": "Delete operation of resource: committed-burst-size",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/peak-information-rate/": {
+            "post": {
+                "summary": "Create peak-information-rate by ID",
+                "description": "Create operation of resource: peak-information-rate",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -10669,13 +10884,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update peak-information-rate by ID",
+                "description": "Update operation of resource: peak-information-rate",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-information-rate by ID",
+                "description": "Delete operation of resource: peak-information-rate",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/peak-burst-size/": {
+            "post": {
+                "summary": "Create peak-burst-size by ID",
+                "description": "Create operation of resource: peak-burst-size",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -10704,6 +11042,85 @@
                         "schema": {
                             "$ref": "#/definitions/capacity-value"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update peak-burst-size by ID",
+                "description": "Update operation of resource: peak-burst-size",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-burst-size by ID",
+                "description": "Delete operation of resource: peak-burst-size",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -11147,6 +11564,43 @@
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/": {
+            "post": {
+                "summary": "Create requested-capacity by ID",
+                "description": "Create operation of resource: requested-capacity",
+                "operationId": "create_context_connectivity-service_requested-capacity_requested-capacity_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "requested-capacity",
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "description": "requested-capacitybody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve requested-capacity",
                 "description": "Retrieve operation of resource: requested-capacity",
@@ -11177,9 +11631,112 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update requested-capacity by ID",
+                "description": "Update operation of resource: requested-capacity",
+                "operationId": "update_context_connectivity-service_requested-capacity_requested-capacity_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "requested-capacity",
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "description": "requested-capacitybody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete requested-capacity by ID",
+                "description": "Delete operation of resource: requested-capacity",
+                "operationId": "delete_context_connectivity-service_requested-capacity_requested-capacity_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/total-size/": {
+            "post": {
+                "summary": "Create total-size by ID",
+                "description": "Create operation of resource: total-size",
+                "operationId": "create_context_connectivity-service_requested-capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "total-size",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
@@ -11211,9 +11768,112 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update total-size by ID",
+                "description": "Update operation of resource: total-size",
+                "operationId": "update_context_connectivity-service_requested-capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "total-size",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete total-size by ID",
+                "description": "Delete operation of resource: total-size",
+                "operationId": "delete_context_connectivity-service_requested-capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/": {
+            "post": {
+                "summary": "Create bandwidth-profile by ID",
+                "description": "Create operation of resource: bandwidth-profile",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
@@ -11244,9 +11904,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update bandwidth-profile by ID",
+                "description": "Update operation of resource: bandwidth-profile",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete bandwidth-profile by ID",
+                "description": "Delete operation of resource: bandwidth-profile",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/committed-information-rate/": {
+            "post": {
+                "summary": "Create committed-information-rate by ID",
+                "description": "Create operation of resource: committed-information-rate",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
@@ -11277,9 +12039,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-information-rate by ID",
+                "description": "Update operation of resource: committed-information-rate",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-information-rate by ID",
+                "description": "Delete operation of resource: committed-information-rate",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/committed-burst-size/": {
+            "post": {
+                "summary": "Create committed-burst-size by ID",
+                "description": "Create operation of resource: committed-burst-size",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
@@ -11310,9 +12174,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-burst-size by ID",
+                "description": "Update operation of resource: committed-burst-size",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-burst-size by ID",
+                "description": "Delete operation of resource: committed-burst-size",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/peak-information-rate/": {
+            "post": {
+                "summary": "Create peak-information-rate by ID",
+                "description": "Create operation of resource: peak-information-rate",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
@@ -11343,9 +12309,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update peak-information-rate by ID",
+                "description": "Update operation of resource: peak-information-rate",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-information-rate by ID",
+                "description": "Delete operation of resource: peak-information-rate",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/peak-burst-size/": {
+            "post": {
+                "summary": "Create peak-burst-size by ID",
+                "description": "Create operation of resource: peak-burst-size",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
@@ -11371,6 +12439,71 @@
                         "schema": {
                             "$ref": "#/definitions/capacity-value"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update peak-burst-size by ID",
+                "description": "Update operation of resource: peak-burst-size",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-burst-size by ID",
+                "description": "Delete operation of resource: peak-burst-size",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -11551,6 +12684,50 @@
             }
         },
         "/config/context/connectivity-service/{uuid}/cost-characteristic/{cost_name}/": {
+            "post": {
+                "summary": "Create cost-characteristic by ID",
+                "description": "Create operation of resource: cost-characteristic",
+                "operationId": "create_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost_name",
+                        "description": "ID of cost_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "cost-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        },
+                        "description": "cost-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
@@ -11583,6 +12760,85 @@
                         "schema": {
                             "$ref": "#/definitions/cost-characteristic"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update cost-characteristic by ID",
+                "description": "Update operation of resource: cost-characteristic",
+                "operationId": "update_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost_name",
+                        "description": "ID of cost_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "cost-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        },
+                        "description": "cost-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete cost-characteristic by ID",
+                "description": "Delete operation of resource: cost-characteristic",
+                "operationId": "delete_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost_name",
+                        "description": "ID of cost_name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -11628,6 +12884,50 @@
             }
         },
         "/config/context/connectivity-service/{uuid}/latency-characteristic/{traffic_property_name}/": {
+            "post": {
+                "summary": "Create latency-characteristic by ID",
+                "description": "Create operation of resource: latency-characteristic",
+                "operationId": "create_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic_property_name",
+                        "description": "ID of traffic_property_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "latency-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        },
+                        "description": "latency-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
@@ -11660,6 +12960,85 @@
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update latency-characteristic by ID",
+                "description": "Update operation of resource: latency-characteristic",
+                "operationId": "update_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic_property_name",
+                        "description": "ID of traffic_property_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "latency-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        },
+                        "description": "latency-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete latency-characteristic by ID",
+                "description": "Delete operation of resource: latency-characteristic",
+                "operationId": "delete_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic_property_name",
+                        "description": "ID of traffic_property_name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -13244,7 +14623,7 @@
                             "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
                         },
                         "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         },
                         "direction": {
                             "type": "string",

--- a/SWAGGER/tapi-connectivity.swagger
+++ b/SWAGGER/tapi-connectivity.swagger
@@ -14099,7 +14099,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/"
                             },
                             "type": "array"
                         }
@@ -14110,7 +14110,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/": {
             "get": {
                 "summary": "Retrieve switch-control by ID",
                 "description": "Retrieve operation of resource: switch-control",
@@ -14131,8 +14131,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -14150,7 +14150,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/": {
             "get": {
                 "summary": "Retrieve switch",
                 "description": "Retrieve operation of resource: switch",
@@ -14171,8 +14171,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -14183,7 +14183,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/"
                             },
                             "type": "array"
                         }
@@ -14194,7 +14194,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/": {
             "get": {
                 "summary": "Retrieve switch by ID",
                 "description": "Retrieve operation of resource: switch",
@@ -14215,8 +14215,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -14241,7 +14241,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/name/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/name/": {
             "get": {
                 "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
@@ -14262,8 +14262,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -14281,7 +14281,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/name/{value_name}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/name/{value_name}/"
                             },
                             "type": "array"
                         }
@@ -14292,7 +14292,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/name/{value_name}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/name/{value_name}/": {
             "get": {
                 "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
@@ -14313,8 +14313,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -14346,7 +14346,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/name/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
@@ -14367,8 +14367,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -14379,7 +14379,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/name/{value_name}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/name/{value_name}/"
                             },
                             "type": "array"
                         }
@@ -14390,7 +14390,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/name/{value_name}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/name/{value_name}/": {
             "get": {
                 "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
@@ -14411,8 +14411,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -14437,7 +14437,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/resilience-type/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/resilience-type/": {
             "get": {
                 "summary": "Retrieve resilience-type",
                 "description": "Retrieve operation of resource: resilience-type",
@@ -14458,8 +14458,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -15047,7 +15047,7 @@
                             "items": {
                                 "$ref": "#/definitions/switch-control"
                             },
-                            "x-key": "local-id"
+                            "x-key": "uuid"
                         },
                         "direction": {
                             "type": "string",
@@ -15428,7 +15428,7 @@
         "switch-control": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/local-class"
+                    "$ref": "#/definitions/resource-spec"
                 },
                 {
                     "$ref": "#/definitions/resilience-constraint"
@@ -15439,7 +15439,7 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:local-id"
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
                             }
                         },
                         "switch": {

--- a/SWAGGER/tapi-connectivity.swagger
+++ b/SWAGGER/tapi-connectivity.swagger
@@ -13686,7 +13686,7 @@
                 }
             }
         },
-        "context": {
+        "tapi-context": {
             "allOf": [
                 {
                     "$ref": "#/definitions/global-class"
@@ -14685,7 +14685,7 @@
         "context_schema": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/context"
+                    "$ref": "#/definitions/tapi-context"
                 },
                 {
                     "properties": {

--- a/SWAGGER/tapi-connectivity.swagger
+++ b/SWAGGER/tapi-connectivity.swagger
@@ -1531,6 +1531,668 @@
                 }
             }
         },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/": {
             "get": {
                 "summary": "Retrieve connection-end-point",
@@ -15460,6 +16122,9 @@
                     "$ref": "#/definitions/termination-pac"
                 },
                 {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "string",
@@ -16234,6 +16899,14 @@
                                 "TERMINATION_STATE_UNKNOWN"
                             ],
                             "description": "Indicates whether the layer is terminated and if so how."
+                        },
+                        "total-potential-capacity": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "available-capacity": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
                         },
                         "connection-end-point": {
                             "type": "array",

--- a/SWAGGER/tapi-connectivity.swagger
+++ b/SWAGGER/tapi-connectivity.swagger
@@ -14403,7 +14403,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         }
                     }
@@ -14432,7 +14433,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "connectivity-service-end-point": {
@@ -14589,7 +14591,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         }
                     }
@@ -14615,7 +14618,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "service-interface-point": {
@@ -14846,7 +14850,8 @@
                         "OTU",
                         "ODU",
                         "ETH",
-                        "ETY"
+                        "ETY",
+                        "DSR"
                     ],
                     "description": "Indicate which layer this resilience parameters package configured for."
                 }
@@ -14922,7 +14927,8 @@
                             "OTU",
                             "ODU",
                             "ETH",
-                            "ETY"
+                            "ETY",
+                            "DSR"
                         ],
                         "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                     }
@@ -15113,7 +15119,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
@@ -15299,7 +15306,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         },
@@ -15377,7 +15385,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -15417,7 +15426,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -15459,7 +15469,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "aggregated-node-edge-point": {
@@ -15899,7 +15910,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         }
                     }
@@ -16005,7 +16017,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         },

--- a/SWAGGER/tapi-eth.swagger
+++ b/SWAGGER/tapi-eth.swagger
@@ -15110,7 +15110,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/"
                             },
                             "type": "array"
                         }
@@ -15121,7 +15121,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/": {
             "get": {
                 "summary": "Retrieve switch-control by ID",
                 "description": "Retrieve operation of resource: switch-control",
@@ -15142,8 +15142,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -15161,7 +15161,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/": {
             "get": {
                 "summary": "Retrieve switch",
                 "description": "Retrieve operation of resource: switch",
@@ -15182,8 +15182,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -15194,7 +15194,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/"
                             },
                             "type": "array"
                         }
@@ -15205,7 +15205,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/": {
             "get": {
                 "summary": "Retrieve switch by ID",
                 "description": "Retrieve operation of resource: switch",
@@ -15226,8 +15226,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -15252,7 +15252,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/name/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/name/": {
             "get": {
                 "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
@@ -15273,8 +15273,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -15292,7 +15292,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/name/{value_name}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/name/{value_name}/"
                             },
                             "type": "array"
                         }
@@ -15303,7 +15303,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/name/{value_name}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/name/{value_name}/": {
             "get": {
                 "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
@@ -15324,8 +15324,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -15357,7 +15357,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/name/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
@@ -15378,8 +15378,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -15390,7 +15390,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/name/{value_name}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/name/{value_name}/"
                             },
                             "type": "array"
                         }
@@ -15401,7 +15401,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/name/{value_name}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/name/{value_name}/": {
             "get": {
                 "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
@@ -15422,8 +15422,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -15448,7 +15448,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/resilience-type/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/resilience-type/": {
             "get": {
                 "summary": "Retrieve resilience-type",
                 "description": "Retrieve operation of resource: resilience-type",
@@ -15469,8 +15469,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -18014,7 +18014,7 @@
                             "items": {
                                 "$ref": "#/definitions/switch-control"
                             },
-                            "x-key": "local-id"
+                            "x-key": "uuid"
                         },
                         "direction": {
                             "type": "string",
@@ -18395,7 +18395,7 @@
         "switch-control": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/local-class"
+                    "$ref": "#/definitions/resource-spec"
                 },
                 {
                     "$ref": "#/definitions/resilience-constraint"
@@ -18406,7 +18406,7 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:local-id"
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
                             }
                         },
                         "switch": {

--- a/SWAGGER/tapi-eth.swagger
+++ b/SWAGGER/tapi-eth.swagger
@@ -16099,7 +16099,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
@@ -16413,7 +16414,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         },
@@ -16491,7 +16493,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -16531,7 +16534,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -16573,7 +16577,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "aggregated-node-edge-point": {
@@ -17354,7 +17359,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         }
                     }
@@ -17383,7 +17389,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "connectivity-service-end-point": {
@@ -17540,7 +17547,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         }
                     }
@@ -17566,7 +17574,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "service-interface-point": {
@@ -17797,7 +17806,8 @@
                         "OTU",
                         "ODU",
                         "ETH",
-                        "ETY"
+                        "ETY",
+                        "DSR"
                     ],
                     "description": "Indicate which layer this resilience parameters package configured for."
                 }
@@ -17873,7 +17883,8 @@
                             "OTU",
                             "ODU",
                             "ETH",
-                            "ETY"
+                            "ETY",
+                            "DSR"
                         ],
                         "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                     }

--- a/SWAGGER/tapi-eth.swagger
+++ b/SWAGGER/tapi-eth.swagger
@@ -2768,11 +2768,230 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/priority-regenerate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/eth-term/": {
+            "post": {
+                "summary": "Create eth-term by ID",
+                "description": "Create operation of resource: eth-term",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_eth-term_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "eth-term",
+                        "schema": {
+                            "$ref": "#/definitions/eth-termination-pac"
+                        },
+                        "description": "eth-termbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve eth-term",
+                "description": "Retrieve operation of resource: eth-term",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_eth-term",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/eth-termination-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update eth-term by ID",
+                "description": "Update operation of resource: eth-term",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_eth-term_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "eth-term",
+                        "schema": {
+                            "$ref": "#/definitions/eth-termination-pac"
+                        },
+                        "description": "eth-termbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete eth-term by ID",
+                "description": "Delete operation of resource: eth-term",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_eth-term_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/eth-term/priority-regenerate/": {
             "post": {
                 "summary": "Create priority-regenerate by ID",
                 "description": "Create operation of resource: priority-regenerate",
-                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_priority-regenerate_priority-regenerate_by_id",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_priority-regenerate_priority-regenerate_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -2831,7 +3050,7 @@
             "get": {
                 "summary": "Retrieve priority-regenerate",
                 "description": "Retrieve operation of resource: priority-regenerate",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_priority-regenerate_priority-regenerate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_priority-regenerate_priority-regenerate",
                 "produces": [
                     "application/json"
                 ],
@@ -2884,7 +3103,7 @@
             "put": {
                 "summary": "Update priority-regenerate by ID",
                 "description": "Update operation of resource: priority-regenerate",
-                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_priority-regenerate_priority-regenerate_by_id",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_priority-regenerate_priority-regenerate_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -2943,7 +3162,7 @@
             "delete": {
                 "summary": "Delete priority-regenerate by ID",
                 "description": "Delete operation of resource: priority-regenerate",
-                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_priority-regenerate_priority-regenerate_by_id",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_priority-regenerate_priority-regenerate_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -2990,11 +3209,230 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/filter-config/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/eth-ctp/": {
+            "post": {
+                "summary": "Create eth-ctp by ID",
+                "description": "Create operation of resource: eth-ctp",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_eth-ctp_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "eth-ctp",
+                        "schema": {
+                            "$ref": "#/definitions/eth-ctp-pac"
+                        },
+                        "description": "eth-ctpbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve eth-ctp",
+                "description": "Retrieve operation of resource: eth-ctp",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_eth-ctp",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/eth-ctp-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update eth-ctp by ID",
+                "description": "Update operation of resource: eth-ctp",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_eth-ctp_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "eth-ctp",
+                        "schema": {
+                            "$ref": "#/definitions/eth-ctp-pac"
+                        },
+                        "description": "eth-ctpbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete eth-ctp by ID",
+                "description": "Delete operation of resource: eth-ctp",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_eth-ctp_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/eth-ctp/filter-config/": {
             "post": {
                 "summary": "Create filter-config by ID",
                 "description": "Create operation of resource: filter-config",
-                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_filter-config_filter-config_by_id",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_filter-config_filter-config_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -3053,7 +3491,7 @@
             "get": {
                 "summary": "Retrieve filter-config",
                 "description": "Retrieve operation of resource: filter-config",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_filter-config_filter-config",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_filter-config_filter-config",
                 "produces": [
                     "application/json"
                 ],
@@ -3106,7 +3544,7 @@
             "put": {
                 "summary": "Update filter-config by ID",
                 "description": "Update operation of resource: filter-config",
-                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_filter-config_filter-config_by_id",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_filter-config_filter-config_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -3165,7 +3603,7 @@
             "delete": {
                 "summary": "Delete filter-config by ID",
                 "description": "Delete operation of resource: filter-config",
-                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_filter-config_filter-config_by_id",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_filter-config_filter-config_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -3212,11 +3650,230 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/prio-config-list/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/eth-ctp/traffic-shaping/": {
+            "post": {
+                "summary": "Create traffic-shaping by ID",
+                "description": "Create operation of resource: traffic-shaping",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_traffic-shaping_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "traffic-shaping",
+                        "schema": {
+                            "$ref": "#/definitions/traffic-shaping-pac"
+                        },
+                        "description": "traffic-shapingbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve traffic-shaping",
+                "description": "Retrieve operation of resource: traffic-shaping",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_traffic-shaping",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/traffic-shaping-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update traffic-shaping by ID",
+                "description": "Update operation of resource: traffic-shaping",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_traffic-shaping_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "traffic-shaping",
+                        "schema": {
+                            "$ref": "#/definitions/traffic-shaping-pac"
+                        },
+                        "description": "traffic-shapingbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete traffic-shaping by ID",
+                "description": "Delete operation of resource: traffic-shaping",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_traffic-shaping_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/eth-ctp/traffic-shaping/prio-config-list/": {
             "get": {
                 "summary": "Retrieve prio-config-list",
                 "description": "Retrieve operation of resource: prio-config-list",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_prio-config-list_prio-config-list",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_prio-config-list_prio-config-list",
                 "produces": [
                     "application/json"
                 ],
@@ -3266,11 +3923,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/queue-config-list/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/eth-ctp/traffic-shaping/queue-config-list/": {
             "get": {
                 "summary": "Retrieve queue-config-list",
                 "description": "Retrieve operation of resource: queue-config-list",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_queue-config-list_queue-config-list",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_queue-config-list_queue-config-list",
                 "produces": [
                     "application/json"
                 ],
@@ -3320,11 +3977,230 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/prio-config-list-1/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/eth-ctp/traffic-conditioning/": {
+            "post": {
+                "summary": "Create traffic-conditioning by ID",
+                "description": "Create operation of resource: traffic-conditioning",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_traffic-conditioning_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "traffic-conditioning",
+                        "schema": {
+                            "$ref": "#/definitions/traffic-conditioning-pac"
+                        },
+                        "description": "traffic-conditioningbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
-                "summary": "Retrieve prio-config-list-1",
-                "description": "Retrieve operation of resource: prio-config-list-1",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_prio-config-list-1_prio-config-list-1",
+                "summary": "Retrieve traffic-conditioning",
+                "description": "Retrieve operation of resource: traffic-conditioning",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_traffic-conditioning",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/traffic-conditioning-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update traffic-conditioning by ID",
+                "description": "Update operation of resource: traffic-conditioning",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_traffic-conditioning_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "traffic-conditioning",
+                        "schema": {
+                            "$ref": "#/definitions/traffic-conditioning-pac"
+                        },
+                        "description": "traffic-conditioningbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete traffic-conditioning by ID",
+                "description": "Delete operation of resource: traffic-conditioning",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_traffic-conditioning_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/eth-ctp/traffic-conditioning/prio-config-list/": {
+            "get": {
+                "summary": "Retrieve prio-config-list",
+                "description": "Retrieve operation of resource: prio-config-list",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_prio-config-list_prio-config-list",
                 "produces": [
                     "application/json"
                 ],
@@ -3374,11 +4250,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/cond-config-list/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/eth-ctp/traffic-conditioning/cond-config-list/": {
             "get": {
                 "summary": "Retrieve cond-config-list",
                 "description": "Retrieve operation of resource: cond-config-list",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_cond-config-list_cond-config-list",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_cond-config-list_cond-config-list",
                 "produces": [
                     "application/json"
                 ],
@@ -3420,6 +4296,53 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/traffic-conditioning-configuration"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/ety-term/": {
+            "get": {
+                "summary": "Retrieve ety-term",
+                "description": "Retrieve operation of resource: ety-term",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_ety-term_ety-term",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/ety-termination-pac"
                         }
                     },
                     "400": {
@@ -16022,106 +16945,109 @@
     },
     "definitions": {
         "eth-ctp-pac": {
-            "allOf": [
-                {
+            "properties": {
+                "auxiliary-function-position-sequence": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "This attribute indicates the positions (i.e., the relative order) of all the MEP, MIP, and TCS objects which are associated with the CTP."
+                    }
+                },
+                "vlan-config": {
+                    "type": "string",
+                    "description": "This attribute models the ETHx/ETH-m_A_So_MI_Vlan_Config information defined in G.8021.\nrange of type : -1, 0, 1..4094"
+                },
+                "csf-rdi-fdi-enable": {
+                    "type": "boolean",
+                    "description": "This attribute models the MI_CSFrdifdiEnable information defined in G.8021."
+                },
+                "csf-report": {
+                    "type": "boolean",
+                    "description": "This attribute models the MI_CSF_Reported information defined in G.8021.\nrange of type : true, false"
+                },
+                "filter-config-snk": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "This attribute models the FilteConfig MI defined in 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n01-80-C2-00-00-10, \n01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and \n01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed."
+                    }
+                },
+                "mac-length": {
+                    "type": "string",
+                    "description": "This attribute models the MAC_Lenght MI defined in 8.6/G.8021 for the MAC Length Check process. It indicates the allowed maximum frame length in bytes.\nrange of type : 1518, 1522, 2000"
+                },
+                "filter-config": {
+                    "description": "This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n- All bridges address: 01-80-C2-00-00-10,\n- Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,\n- GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed.",
+                    "$ref": "#/definitions/control-frame-filter"
+                },
+                "is-ssf-reported": {
+                    "type": "boolean",
+                    "description": "This attribute provisions whether the SSF defect should be reported as fault cause or not.\nIt models the ETH-LAG_FT_Sk_MI_SSF_Reported defined in G.8021."
+                },
+                "pll-thr": {
+                    "type": "string",
+                    "description": "This attribute provisions the threshold for the number of active ports. If the number of active ports is more than zero but less than the provisioned threshold, a cPLL (Partial Link Loss) is raised. See section 9.7.1.2 of G.8021.\nrange of type : 0..number of ports"
+                },
+                "actor-oper-key": {
+                    "type": "string",
+                    "description": "See 802.1AX:\nThe current operational value of the Key for the Aggregator. The administrative Key value may differ from the operational Key value for the reasons discussed in 5.6.2.\nThe meaning of particular Key values is of local significance.\nrange of type : 16 bit"
+                },
+                "actor-system-id": {
+                    "type": "string",
+                    "description": "See 802.1AX:\nA MAC address used as a unique identifier for the System that contains this Aggregator."
+                },
+                "actor-system-priority": {
+                    "type": "string",
+                    "description": "See 802.1AX:\nIndicating the priority associated with the Actor\u2019s System ID.\nrange of type : 2-octet"
+                },
+                "collector-max-delay": {
+                    "type": "string",
+                    "description": "See 802.1AX:\nThe value of this attribute defines the maximum delay, in tens of microseconds, that may be imposed by the Frame Collector between receiving a frame from an Aggregator Parser, and either delivering the frame to its MAC Client or discarding the frame (see IEEE 802.1AX clause 5.2.3.1.1).\nrange of type : 16-bit"
+                },
+                "data-rate": {
+                    "type": "string",
+                    "description": "See 802.1AX:\nThe current data rate, in bits per second, of the aggregate link. The value is calculated as N times the data rate of a single link in the aggregation, where N is the number of active links."
+                },
+                "partner-oper-key": {
+                    "type": "string",
+                    "description": "See 802.1AX:\nThe current operational value of the Key for the Aggregator\u2019s current protocol Partner. If the aggregation is manually configured, this Key value will be a value assigned by the local System.\nrange of type : 16-bit"
+                },
+                "partner-system-id": {
+                    "type": "string",
+                    "description": "See 802.1AX:\nA MAC address consisting of the unique identifier for the current protocol Partner of this Aggregator. A value of zero indicates that there is no known Partner. If the aggregation is manually configured, this System ID value will be a value assigned by the local System."
+                },
+                "partner-system-priority": {
+                    "type": "string",
+                    "description": "See 802.1AX:\nIndicates the priority associated with the Partner\u2019s System ID. If the aggregation is manually configured, this System Priority value will be a value assigned by the local System.\nrange of type : 2-octet"
+                },
+                "csf-config": {
+                    "type": "string",
+                    "enum": [
+                        "DISABLED",
+                        "ENABLED",
+                        "ENABLED_WITH_RDI_FDI",
+                        "ENABLED_WITH_RDI_FDI_DCI",
+                        "ENABLED_WITH_DCI"
+                    ],
+                    "description": "This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.\nrange of type : true, false"
+                },
+                "traffic-shaping": {
                     "$ref": "#/definitions/traffic-shaping-pac"
                 },
-                {
+                "traffic-conditioning": {
                     "$ref": "#/definitions/traffic-conditioning-pac"
-                },
-                {
-                    "properties": {
-                        "auxiliary-function-position-sequence": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "description": "This attribute indicates the positions (i.e., the relative order) of all the MEP, MIP, and TCS objects which are associated with the CTP."
-                            }
-                        },
-                        "vlan-config": {
-                            "type": "string",
-                            "description": "This attribute models the ETHx/ETH-m_A_So_MI_Vlan_Config information defined in G.8021.\nrange of type : -1, 0, 1..4094"
-                        },
-                        "csf-rdi-fdi-enable": {
-                            "type": "boolean",
-                            "description": "This attribute models the MI_CSFrdifdiEnable information defined in G.8021."
-                        },
-                        "csf-report": {
-                            "type": "boolean",
-                            "description": "This attribute models the MI_CSF_Reported information defined in G.8021.\nrange of type : true, false"
-                        },
-                        "filter-config-snk": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "description": "This attribute models the FilteConfig MI defined in 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n01-80-C2-00-00-10, \n01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and \n01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed."
-                            }
-                        },
-                        "mac-length": {
-                            "type": "string",
-                            "description": "This attribute models the MAC_Lenght MI defined in 8.6/G.8021 for the MAC Length Check process. It indicates the allowed maximum frame length in bytes.\nrange of type : 1518, 1522, 2000"
-                        },
-                        "filter-config": {
-                            "description": "This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n- All bridges address: 01-80-C2-00-00-10,\n- Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,\n- GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed.",
-                            "$ref": "#/definitions/control-frame-filter"
-                        },
-                        "is-ssf-reported": {
-                            "type": "boolean",
-                            "description": "This attribute provisions whether the SSF defect should be reported as fault cause or not.\nIt models the ETH-LAG_FT_Sk_MI_SSF_Reported defined in G.8021."
-                        },
-                        "pll-thr": {
-                            "type": "string",
-                            "description": "This attribute provisions the threshold for the number of active ports. If the number of active ports is more than zero but less than the provisioned threshold, a cPLL (Partial Link Loss) is raised. See section 9.7.1.2 of G.8021.\nrange of type : 0..number of ports"
-                        },
-                        "actor-oper-key": {
-                            "type": "string",
-                            "description": "See 802.1AX:\nThe current operational value of the Key for the Aggregator. The administrative Key value may differ from the operational Key value for the reasons discussed in 5.6.2.\nThe meaning of particular Key values is of local significance.\nrange of type : 16 bit"
-                        },
-                        "actor-system-id": {
-                            "type": "string",
-                            "description": "See 802.1AX:\nA MAC address used as a unique identifier for the System that contains this Aggregator."
-                        },
-                        "actor-system-priority": {
-                            "type": "string",
-                            "description": "See 802.1AX:\nIndicating the priority associated with the Actor\u2019s System ID.\nrange of type : 2-octet"
-                        },
-                        "collector-max-delay": {
-                            "type": "string",
-                            "description": "See 802.1AX:\nThe value of this attribute defines the maximum delay, in tens of microseconds, that may be imposed by the Frame Collector between receiving a frame from an Aggregator Parser, and either delivering the frame to its MAC Client or discarding the frame (see IEEE 802.1AX clause 5.2.3.1.1).\nrange of type : 16-bit"
-                        },
-                        "data-rate": {
-                            "type": "string",
-                            "description": "See 802.1AX:\nThe current data rate, in bits per second, of the aggregate link. The value is calculated as N times the data rate of a single link in the aggregation, where N is the number of active links."
-                        },
-                        "partner-oper-key": {
-                            "type": "string",
-                            "description": "See 802.1AX:\nThe current operational value of the Key for the Aggregator\u2019s current protocol Partner. If the aggregation is manually configured, this Key value will be a value assigned by the local System.\nrange of type : 16-bit"
-                        },
-                        "partner-system-id": {
-                            "type": "string",
-                            "description": "See 802.1AX:\nA MAC address consisting of the unique identifier for the current protocol Partner of this Aggregator. A value of zero indicates that there is no known Partner. If the aggregation is manually configured, this System ID value will be a value assigned by the local System."
-                        },
-                        "partner-system-priority": {
-                            "type": "string",
-                            "description": "See 802.1AX:\nIndicates the priority associated with the Partner\u2019s System ID. If the aggregation is manually configured, this System Priority value will be a value assigned by the local System.\nrange of type : 2-octet"
-                        },
-                        "csf-config": {
-                            "type": "string",
-                            "enum": [
-                                "DISABLED",
-                                "ENABLED",
-                                "ENABLED_WITH_RDI_FDI",
-                                "ENABLED_WITH_RDI_FDI_DCI",
-                                "ENABLED_WITH_DCI"
-                            ],
-                            "description": "This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.\nrange of type : true, false"
-                        }
-                    }
                 }
-            ]
+            }
         },
         "eth-connection-end-point-spec": {
-            "$ref": "#/definitions/eth-ctp-pac"
+            "properties": {
+                "eth-term": {
+                    "$ref": "#/definitions/eth-termination-pac"
+                },
+                "eth-ctp": {
+                    "$ref": "#/definitions/eth-ctp-pac"
+                }
+            }
         },
         "eth-termination-pac": {
             "description": "This object class models the Ethernet Flow Termination function located at a layer boundary.",
@@ -16230,7 +17156,7 @@
         "traffic-conditioning-pac": {
             "description": "This object class models the ETH traffic conditioning function as defined in G.8021.\nBasic attributes: codirectional, condConfigList, prioConfigList",
             "properties": {
-                "prio-config-list-1": {
+                "prio-config-list": {
                     "description": "This attribute indicates the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.",
                     "type": "array",
                     "items": {
@@ -16244,7 +17170,7 @@
                         "$ref": "#/definitions/traffic-conditioning-configuration"
                     }
                 },
-                "codirectional-1": {
+                "codirectional": {
                     "type": "boolean",
                     "description": "This attribute indicates the direction of the conditioner. The value of true means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the sink part of the containing CTP. The value of false means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the source part of the containing CTP."
                 }
@@ -16278,7 +17204,11 @@
             }
         },
         "eth-node-edge-point-spec": {
-            "$ref": "#/definitions/ety-termination-pac"
+            "properties": {
+                "ety-term": {
+                    "$ref": "#/definitions/ety-termination-pac"
+                }
+            }
         },
         "priority-configuration": {
             "properties": {
@@ -16981,56 +17911,8 @@
                             },
                             "x-key": "uuid"
                         },
-                        "is-fts-enabled": {
-                            "type": "boolean",
-                            "description": "This attribute indicates whether Forced Transmitter Shutdown (FTS) is enabled or not. It models the ETYn_TT_So_MI_FTSEnable information."
-                        },
-                        "is-tx-pause-enabled": {
-                            "type": "boolean",
-                            "description": "This attribute identifies whether the Transmit Pause process is enabled or not. It models the MI_TxPauseEnable defined in G.8021."
-                        },
-                        "phy-type": {
-                            "type": "string",
-                            "enum": [
-                                "OTHER",
-                                "UNKNOWN",
-                                "NONE",
-                                "2BASE_TL",
-                                "10MBIT_S",
-                                "10PASS_TS",
-                                "100BASE_T4",
-                                "100BASE_X",
-                                "100BASE_T2",
-                                "1000BASE_X",
-                                "1000BASE_T",
-                                "10GBASE-X",
-                                "10GBASE_R",
-                                "10GBASE_W"
-                            ],
-                            "description": "This attribute identifies the PHY type of the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.2."
-                        },
-                        "phy-type-list": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "OTHER",
-                                    "UNKNOWN",
-                                    "NONE",
-                                    "2BASE_TL",
-                                    "10MBIT_S",
-                                    "10PASS_TS",
-                                    "100BASE_T4",
-                                    "100BASE_X",
-                                    "100BASE_T2",
-                                    "1000BASE_X",
-                                    "1000BASE_T",
-                                    "10GBASE-X",
-                                    "10GBASE_R",
-                                    "10GBASE_W"
-                                ],
-                                "description": "This attribute identifies the possible PHY types that could be supported at the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.3."
-                            }
+                        "ety-term": {
+                            "$ref": "#/definitions/ety-termination-pac"
                         }
                     }
                 }
@@ -17804,174 +18686,11 @@
                             ],
                             "description": "Indicates whether the layer is terminated and if so how."
                         },
-                        "priority-regenerate": {
-                            "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_P_Regenerate information defined in G.8021.",
-                            "$ref": "#/definitions/priority-mapping"
+                        "eth-term": {
+                            "$ref": "#/definitions/eth-termination-pac"
                         },
-                        "ether-type": {
-                            "type": "string",
-                            "enum": [
-                                "C_Tag",
-                                "S_Tag",
-                                "I_Tag"
-                            ],
-                            "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_Etype information defined in G.8021."
-                        },
-                        "filter-config-1": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "description": "This attribute models the ETHx/ETH-m_A_Sk_MI_Filter_Config information defined in G.8021.\nIt indicates the configured filter action for each of the 33 group MAC addresses for control frames.\nThe 33 MAC addresses are:\n01-80-C2-00-00-10, \n01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and \n01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed.\nrange of type : MacAddress: \n01-80-C2-00-00-10, \n01-80-C2-00-00-00 to \n01-80-C2-00-00-0F, and \n01-80-C2-00-00-20 to \n01-80-C2-00-00-2F;\nActionEnum:\nPASS, BLOCK"
-                            }
-                        },
-                        "frametype-config": {
-                            "type": "string",
-                            "enum": [
-                                "ADMIT_ONLY_VLAN_TAGGED_FRAMES",
-                                "ADMIT_ONLY_UNTAGGED_AND_PRIORITY_TAGGED_FRAMES",
-                                "ADMIT_ALL_FRAMES"
-                            ],
-                            "description": "This attribute models the ETHx/ETH-m_A_Sk_MI_Frametype_Config information defined in G.8021.\nrange of type : see Enumeration"
-                        },
-                        "port-vid": {
-                            "type": "string",
-                            "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_PVID information defined in G.8021."
-                        },
-                        "priority-code-point-config": {
-                            "type": "string",
-                            "enum": [
-                                "8P0D",
-                                "7P1D",
-                                "6P2D",
-                                "5P3D",
-                                "DEI"
-                            ],
-                            "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_PCP_Config information defined in G.8021.\nrange of type : see Enumeration"
-                        },
-                        "auxiliary-function-position-sequence": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "description": "This attribute indicates the positions (i.e., the relative order) of all the MEP, MIP, and TCS objects which are associated with the CTP."
-                            }
-                        },
-                        "vlan-config": {
-                            "type": "string",
-                            "description": "This attribute models the ETHx/ETH-m_A_So_MI_Vlan_Config information defined in G.8021.\nrange of type : -1, 0, 1..4094"
-                        },
-                        "csf-rdi-fdi-enable": {
-                            "type": "boolean",
-                            "description": "This attribute models the MI_CSFrdifdiEnable information defined in G.8021."
-                        },
-                        "csf-report": {
-                            "type": "boolean",
-                            "description": "This attribute models the MI_CSF_Reported information defined in G.8021.\nrange of type : true, false"
-                        },
-                        "filter-config-snk": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "description": "This attribute models the FilteConfig MI defined in 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n01-80-C2-00-00-10, \n01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and \n01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed."
-                            }
-                        },
-                        "mac-length": {
-                            "type": "string",
-                            "description": "This attribute models the MAC_Lenght MI defined in 8.6/G.8021 for the MAC Length Check process. It indicates the allowed maximum frame length in bytes.\nrange of type : 1518, 1522, 2000"
-                        },
-                        "filter-config": {
-                            "description": "This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n- All bridges address: 01-80-C2-00-00-10,\n- Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,\n- GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed.",
-                            "$ref": "#/definitions/control-frame-filter"
-                        },
-                        "is-ssf-reported": {
-                            "type": "boolean",
-                            "description": "This attribute provisions whether the SSF defect should be reported as fault cause or not.\nIt models the ETH-LAG_FT_Sk_MI_SSF_Reported defined in G.8021."
-                        },
-                        "pll-thr": {
-                            "type": "string",
-                            "description": "This attribute provisions the threshold for the number of active ports. If the number of active ports is more than zero but less than the provisioned threshold, a cPLL (Partial Link Loss) is raised. See section 9.7.1.2 of G.8021.\nrange of type : 0..number of ports"
-                        },
-                        "actor-oper-key": {
-                            "type": "string",
-                            "description": "See 802.1AX:\nThe current operational value of the Key for the Aggregator. The administrative Key value may differ from the operational Key value for the reasons discussed in 5.6.2.\nThe meaning of particular Key values is of local significance.\nrange of type : 16 bit"
-                        },
-                        "actor-system-id": {
-                            "type": "string",
-                            "description": "See 802.1AX:\nA MAC address used as a unique identifier for the System that contains this Aggregator."
-                        },
-                        "actor-system-priority": {
-                            "type": "string",
-                            "description": "See 802.1AX:\nIndicating the priority associated with the Actor\u2019s System ID.\nrange of type : 2-octet"
-                        },
-                        "collector-max-delay": {
-                            "type": "string",
-                            "description": "See 802.1AX:\nThe value of this attribute defines the maximum delay, in tens of microseconds, that may be imposed by the Frame Collector between receiving a frame from an Aggregator Parser, and either delivering the frame to its MAC Client or discarding the frame (see IEEE 802.1AX clause 5.2.3.1.1).\nrange of type : 16-bit"
-                        },
-                        "data-rate": {
-                            "type": "string",
-                            "description": "See 802.1AX:\nThe current data rate, in bits per second, of the aggregate link. The value is calculated as N times the data rate of a single link in the aggregation, where N is the number of active links."
-                        },
-                        "partner-oper-key": {
-                            "type": "string",
-                            "description": "See 802.1AX:\nThe current operational value of the Key for the Aggregator\u2019s current protocol Partner. If the aggregation is manually configured, this Key value will be a value assigned by the local System.\nrange of type : 16-bit"
-                        },
-                        "partner-system-id": {
-                            "type": "string",
-                            "description": "See 802.1AX:\nA MAC address consisting of the unique identifier for the current protocol Partner of this Aggregator. A value of zero indicates that there is no known Partner. If the aggregation is manually configured, this System ID value will be a value assigned by the local System."
-                        },
-                        "partner-system-priority": {
-                            "type": "string",
-                            "description": "See 802.1AX:\nIndicates the priority associated with the Partner\u2019s System ID. If the aggregation is manually configured, this System Priority value will be a value assigned by the local System.\nrange of type : 2-octet"
-                        },
-                        "csf-config": {
-                            "type": "string",
-                            "enum": [
-                                "DISABLED",
-                                "ENABLED",
-                                "ENABLED_WITH_RDI_FDI",
-                                "ENABLED_WITH_RDI_FDI_DCI",
-                                "ENABLED_WITH_DCI"
-                            ],
-                            "description": "This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.\nrange of type : true, false"
-                        },
-                        "prio-config-list": {
-                            "description": "This attribute configures the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/priority-configuration"
-                            }
-                        },
-                        "queue-config-list": {
-                            "description": "This attribute configures the Queue depth and Dropping threshold parameters of the Queue process. The Queue depth sets the maximum size of the queue in bytes. An incoming ETH_CI traffic unit is dropped if there is insufficient space in the queue to hold the whole unit. The Dropping threshold sets the threshold of the queue. If the queue is filled beyond this threshold, incoming ETH_CI traffic units accompanied by the ETH_CI_DE signal set are dropped.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/queue-configuration"
-                            }
-                        },
-                        "sched-config": {
-                            "type": "string",
-                            "description": "This attribute configures the scheduler process. The value of this attribute is for further study because it is for further study in G.8021.\nScheduler is a pointer to a Scheduler object, which is to be defined in the future (because in G.8021, this is FFS).\nNote that the only significance of the GTCS function defined in G.8021 is the use of a common scheduler for shaping. Given that, G.8052 models the common scheduler feature by having a common value for this attribute."
-                        },
-                        "codirectional": {
-                            "type": "boolean",
-                            "description": "This attribute indicates the direction of the shaping function. The value of true means that the shaping (modeled as a TCS Source according to G.8021) is associated with the source part of the containing CTP. The value of false means that the shaping (modeled as a TCS Source according to G.8021) is associated with the sink part of the containing CTP."
-                        },
-                        "prio-config-list-1": {
-                            "description": "This attribute indicates the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/priority-configuration"
-                            }
-                        },
-                        "cond-config-list": {
-                            "description": "This attribute indicates for the conditioner process the conditioning parameters:\n- Queue ID: Indicates the Queue ID\n- Committed Information Rate (CIR): number of bits per second\n- Committed Burst Size (CBS): number of bytes\n- Excess Information Rate (EIR): number of bits per second\n- Excess Burst Size (EBS): number of bytes\n- Coupling flag (CF): 0 or 1\n- Color mode (CM): color-blind and color-aware.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/traffic-conditioning-configuration"
-                            }
-                        },
-                        "codirectional-1": {
-                            "type": "boolean",
-                            "description": "This attribute indicates the direction of the conditioner. The value of true means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the sink part of the containing CTP. The value of false means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the source part of the containing CTP."
+                        "eth-ctp": {
+                            "$ref": "#/definitions/eth-ctp-pac"
                         }
                     }
                 }

--- a/SWAGGER/tapi-eth.swagger
+++ b/SWAGGER/tapi-eth.swagger
@@ -14515,7 +14515,7 @@
         "context_schema": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/context"
+                    "$ref": "#/definitions/tapi-context"
                 },
                 {
                     "properties": {
@@ -14672,7 +14672,7 @@
                 }
             }
         },
-        "context": {
+        "tapi-context": {
             "allOf": [
                 {
                     "$ref": "#/definitions/global-class"

--- a/SWAGGER/tapi-eth.swagger
+++ b/SWAGGER/tapi-eth.swagger
@@ -1531,6 +1531,668 @@
                 }
             }
         },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/": {
             "get": {
                 "summary": "Retrieve connection-end-point",
@@ -16304,6 +16966,14 @@
                             ],
                             "description": "Indicates whether the layer is terminated and if so how."
                         },
+                        "total-potential-capacity": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "available-capacity": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        },
                         "connection-end-point": {
                             "type": "array",
                             "items": {
@@ -16566,6 +17236,9 @@
                 },
                 {
                     "$ref": "#/definitions/termination-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
                 },
                 {
                     "properties": {

--- a/SWAGGER/tapi-eth.swagger
+++ b/SWAGGER/tapi-eth.swagger
@@ -11025,7 +11025,7 @@
                         "in": "body",
                         "name": "capacity",
                         "schema": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         },
                         "description": "capacitybody object",
                         "required": true
@@ -11070,7 +11070,7 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         }
                     },
                     "400": {
@@ -11107,7 +11107,7 @@
                         "in": "body",
                         "name": "capacity",
                         "schema": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         },
                         "description": "capacitybody object",
                         "required": true
@@ -11158,11 +11158,11 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_total-potential-capacity",
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-size/": {
+            "post": {
+                "summary": "Create total-size by ID",
+                "description": "Create operation of resource: total-size",
+                "operationId": "create_context_connectivity-service_end-point_capacity_total-size_total-size_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -11183,27 +11183,31 @@
                         "description": "ID of local_id",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "total-size",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/total-size/": {
+            },
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_total-size_total-size",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -11238,13 +11242,11 @@
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+            },
+            "put": {
+                "summary": "Update total-size by ID",
+                "description": "Update operation of resource: total-size",
+                "operationId": "update_context_connectivity-service_end-point_capacity_total-size_total-size_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -11265,256 +11267,56 @@
                         "description": "ID of local_id",
                         "required": true,
                         "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
                     },
                     {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
+                        "in": "body",
+                        "name": "total-size",
                         "schema": {
                             "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
                             "$ref": "#/definitions/capacity-value"
-                        }
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete total-size by ID",
+                "description": "Delete operation of resource: total-size",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -11522,11 +11324,55 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/": {
+            "post": {
+                "summary": "Create bandwidth-profile by ID",
+                "description": "Create operation of resource: bandwidth-profile",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -11560,13 +11406,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update bandwidth-profile by ID",
+                "description": "Update operation of resource: bandwidth-profile",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete bandwidth-profile by ID",
+                "description": "Delete operation of resource: bandwidth-profile",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/committed-information-rate/": {
+            "post": {
+                "summary": "Create committed-information-rate by ID",
+                "description": "Create operation of resource: committed-information-rate",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -11600,13 +11569,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-information-rate by ID",
+                "description": "Update operation of resource: committed-information-rate",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-information-rate by ID",
+                "description": "Delete operation of resource: committed-information-rate",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/committed-burst-size/": {
+            "post": {
+                "summary": "Create committed-burst-size by ID",
+                "description": "Create operation of resource: committed-burst-size",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -11640,13 +11732,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-burst-size by ID",
+                "description": "Update operation of resource: committed-burst-size",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-burst-size by ID",
+                "description": "Delete operation of resource: committed-burst-size",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/peak-information-rate/": {
+            "post": {
+                "summary": "Create peak-information-rate by ID",
+                "description": "Create operation of resource: peak-information-rate",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -11680,13 +11895,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update peak-information-rate by ID",
+                "description": "Update operation of resource: peak-information-rate",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-information-rate by ID",
+                "description": "Delete operation of resource: peak-information-rate",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/peak-burst-size/": {
+            "post": {
+                "summary": "Create peak-burst-size by ID",
+                "description": "Create operation of resource: peak-burst-size",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -11715,6 +12053,85 @@
                         "schema": {
                             "$ref": "#/definitions/capacity-value"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update peak-burst-size by ID",
+                "description": "Update operation of resource: peak-burst-size",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-burst-size by ID",
+                "description": "Delete operation of resource: peak-burst-size",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -12158,6 +12575,43 @@
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/": {
+            "post": {
+                "summary": "Create requested-capacity by ID",
+                "description": "Create operation of resource: requested-capacity",
+                "operationId": "create_context_connectivity-service_requested-capacity_requested-capacity_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "requested-capacity",
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "description": "requested-capacitybody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve requested-capacity",
                 "description": "Retrieve operation of resource: requested-capacity",
@@ -12188,9 +12642,112 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update requested-capacity by ID",
+                "description": "Update operation of resource: requested-capacity",
+                "operationId": "update_context_connectivity-service_requested-capacity_requested-capacity_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "requested-capacity",
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "description": "requested-capacitybody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete requested-capacity by ID",
+                "description": "Delete operation of resource: requested-capacity",
+                "operationId": "delete_context_connectivity-service_requested-capacity_requested-capacity_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/total-size/": {
+            "post": {
+                "summary": "Create total-size by ID",
+                "description": "Create operation of resource: total-size",
+                "operationId": "create_context_connectivity-service_requested-capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "total-size",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
@@ -12222,9 +12779,112 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update total-size by ID",
+                "description": "Update operation of resource: total-size",
+                "operationId": "update_context_connectivity-service_requested-capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "total-size",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete total-size by ID",
+                "description": "Delete operation of resource: total-size",
+                "operationId": "delete_context_connectivity-service_requested-capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/": {
+            "post": {
+                "summary": "Create bandwidth-profile by ID",
+                "description": "Create operation of resource: bandwidth-profile",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
@@ -12255,9 +12915,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update bandwidth-profile by ID",
+                "description": "Update operation of resource: bandwidth-profile",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete bandwidth-profile by ID",
+                "description": "Delete operation of resource: bandwidth-profile",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/committed-information-rate/": {
+            "post": {
+                "summary": "Create committed-information-rate by ID",
+                "description": "Create operation of resource: committed-information-rate",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
@@ -12288,9 +13050,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-information-rate by ID",
+                "description": "Update operation of resource: committed-information-rate",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-information-rate by ID",
+                "description": "Delete operation of resource: committed-information-rate",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/committed-burst-size/": {
+            "post": {
+                "summary": "Create committed-burst-size by ID",
+                "description": "Create operation of resource: committed-burst-size",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
@@ -12321,9 +13185,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-burst-size by ID",
+                "description": "Update operation of resource: committed-burst-size",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-burst-size by ID",
+                "description": "Delete operation of resource: committed-burst-size",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/peak-information-rate/": {
+            "post": {
+                "summary": "Create peak-information-rate by ID",
+                "description": "Create operation of resource: peak-information-rate",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
@@ -12354,9 +13320,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update peak-information-rate by ID",
+                "description": "Update operation of resource: peak-information-rate",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-information-rate by ID",
+                "description": "Delete operation of resource: peak-information-rate",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/peak-burst-size/": {
+            "post": {
+                "summary": "Create peak-burst-size by ID",
+                "description": "Create operation of resource: peak-burst-size",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
@@ -12382,6 +13450,71 @@
                         "schema": {
                             "$ref": "#/definitions/capacity-value"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update peak-burst-size by ID",
+                "description": "Update operation of resource: peak-burst-size",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-burst-size by ID",
+                "description": "Delete operation of resource: peak-burst-size",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -12562,6 +13695,50 @@
             }
         },
         "/config/context/connectivity-service/{uuid}/cost-characteristic/{cost_name}/": {
+            "post": {
+                "summary": "Create cost-characteristic by ID",
+                "description": "Create operation of resource: cost-characteristic",
+                "operationId": "create_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost_name",
+                        "description": "ID of cost_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "cost-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        },
+                        "description": "cost-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
@@ -12594,6 +13771,85 @@
                         "schema": {
                             "$ref": "#/definitions/cost-characteristic"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update cost-characteristic by ID",
+                "description": "Update operation of resource: cost-characteristic",
+                "operationId": "update_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost_name",
+                        "description": "ID of cost_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "cost-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        },
+                        "description": "cost-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete cost-characteristic by ID",
+                "description": "Delete operation of resource: cost-characteristic",
+                "operationId": "delete_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost_name",
+                        "description": "ID of cost_name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -12639,6 +13895,50 @@
             }
         },
         "/config/context/connectivity-service/{uuid}/latency-characteristic/{traffic_property_name}/": {
+            "post": {
+                "summary": "Create latency-characteristic by ID",
+                "description": "Create operation of resource: latency-characteristic",
+                "operationId": "create_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic_property_name",
+                        "description": "ID of traffic_property_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "latency-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        },
+                        "description": "latency-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
@@ -12671,6 +13971,85 @@
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update latency-characteristic by ID",
+                "description": "Update operation of resource: latency-characteristic",
+                "operationId": "update_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic_property_name",
+                        "description": "ID of traffic_property_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "latency-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        },
+                        "description": "latency-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete latency-characteristic by ID",
+                "description": "Delete operation of resource: latency-characteristic",
+                "operationId": "delete_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic_property_name",
+                        "description": "ID of traffic_property_name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -16195,7 +17574,7 @@
                             "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
                         },
                         "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         },
                         "direction": {
                             "type": "string",

--- a/SWAGGER/tapi-notification.swagger
+++ b/SWAGGER/tapi-notification.swagger
@@ -3555,7 +3555,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         },
@@ -3639,7 +3640,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "changed-attributes": {
@@ -3919,7 +3921,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }

--- a/SWAGGER/tapi-notification.swagger
+++ b/SWAGGER/tapi-notification.swagger
@@ -3498,7 +3498,17 @@
                                     "PATH_COMPUTATION_SERVICE",
                                     "NODE_EDGE_POINT",
                                     "SERVICE_INTERFACE_POINT",
-                                    "CONNECTION_END_POINT"
+                                    "CONNECTION_END_POINT",
+                                    "MAINTENANCE_ENTITY_GROUP",
+                                    "MAINTENANCE_ENTITY",
+                                    "MEG_END_POINT",
+                                    "MEG_INTERMEDIATE_POINT",
+                                    "SWITCH_CONTROL",
+                                    "SWITCH",
+                                    "ROUTE",
+                                    "NODE_RULE_GROUP",
+                                    "INTER_RULE_GROUP",
+                                    "RULE"
                                 ]
                             }
                         }
@@ -3541,7 +3551,17 @@
                                     "PATH_COMPUTATION_SERVICE",
                                     "NODE_EDGE_POINT",
                                     "SERVICE_INTERFACE_POINT",
-                                    "CONNECTION_END_POINT"
+                                    "CONNECTION_END_POINT",
+                                    "MAINTENANCE_ENTITY_GROUP",
+                                    "MAINTENANCE_ENTITY",
+                                    "MEG_END_POINT",
+                                    "MEG_INTERMEDIATE_POINT",
+                                    "SWITCH_CONTROL",
+                                    "SWITCH",
+                                    "ROUTE",
+                                    "NODE_RULE_GROUP",
+                                    "INTER_RULE_GROUP",
+                                    "RULE"
                                 ]
                             }
                         },
@@ -3604,7 +3624,17 @@
                                 "PATH_COMPUTATION_SERVICE",
                                 "NODE_EDGE_POINT",
                                 "SERVICE_INTERFACE_POINT",
-                                "CONNECTION_END_POINT"
+                                "CONNECTION_END_POINT",
+                                "MAINTENANCE_ENTITY_GROUP",
+                                "MAINTENANCE_ENTITY",
+                                "MEG_END_POINT",
+                                "MEG_INTERMEDIATE_POINT",
+                                "SWITCH_CONTROL",
+                                "SWITCH",
+                                "ROUTE",
+                                "NODE_RULE_GROUP",
+                                "INTER_RULE_GROUP",
+                                "RULE"
                             ]
                         },
                         "target-object-identifier": {
@@ -4127,7 +4157,17 @@
                             "PATH_COMPUTATION_SERVICE",
                             "NODE_EDGE_POINT",
                             "SERVICE_INTERFACE_POINT",
-                            "CONNECTION_END_POINT"
+                            "CONNECTION_END_POINT",
+                            "MAINTENANCE_ENTITY_GROUP",
+                            "MAINTENANCE_ENTITY",
+                            "MEG_END_POINT",
+                            "MEG_INTERMEDIATE_POINT",
+                            "SWITCH_CONTROL",
+                            "SWITCH",
+                            "ROUTE",
+                            "NODE_RULE_GROUP",
+                            "INTER_RULE_GROUP",
+                            "RULE"
                         ]
                     }
                 }

--- a/SWAGGER/tapi-notification.swagger
+++ b/SWAGGER/tapi-notification.swagger
@@ -3871,7 +3871,7 @@
                 }
             }
         },
-        "context": {
+        "tapi-context": {
             "allOf": [
                 {
                     "$ref": "#/definitions/global-class"
@@ -4060,7 +4060,7 @@
         "context_schema": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/context"
+                    "$ref": "#/definitions/tapi-context"
                 },
                 {
                     "properties": {

--- a/SWAGGER/tapi-oam.swagger
+++ b/SWAGGER/tapi-oam.swagger
@@ -14450,7 +14450,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/"
                             },
                             "type": "array"
                         }
@@ -14461,7 +14461,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/": {
             "get": {
                 "summary": "Retrieve switch-control by ID",
                 "description": "Retrieve operation of resource: switch-control",
@@ -14482,8 +14482,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -14501,7 +14501,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/": {
             "get": {
                 "summary": "Retrieve switch",
                 "description": "Retrieve operation of resource: switch",
@@ -14522,8 +14522,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -14534,7 +14534,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/"
                             },
                             "type": "array"
                         }
@@ -14545,7 +14545,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/": {
             "get": {
                 "summary": "Retrieve switch by ID",
                 "description": "Retrieve operation of resource: switch",
@@ -14566,8 +14566,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -14592,7 +14592,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/name/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/name/": {
             "get": {
                 "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
@@ -14613,8 +14613,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -14632,7 +14632,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/name/{value_name}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/name/{value_name}/"
                             },
                             "type": "array"
                         }
@@ -14643,7 +14643,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/name/{value_name}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/name/{value_name}/": {
             "get": {
                 "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
@@ -14664,8 +14664,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -14697,7 +14697,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/name/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
@@ -14718,8 +14718,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -14730,7 +14730,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/name/{value_name}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/name/{value_name}/"
                             },
                             "type": "array"
                         }
@@ -14741,7 +14741,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/name/{value_name}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/name/{value_name}/": {
             "get": {
                 "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
@@ -14762,8 +14762,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -14788,7 +14788,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/resilience-type/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/resilience-type/": {
             "get": {
                 "summary": "Retrieve resilience-type",
                 "description": "Retrieve operation of resource: resilience-type",
@@ -14809,8 +14809,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -18540,7 +18540,7 @@
                             "items": {
                                 "$ref": "#/definitions/switch-control"
                             },
-                            "x-key": "local-id"
+                            "x-key": "uuid"
                         },
                         "direction": {
                             "type": "string",
@@ -18921,7 +18921,7 @@
         "switch-control": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/local-class"
+                    "$ref": "#/definitions/resource-spec"
                 },
                 {
                     "$ref": "#/definitions/resilience-constraint"
@@ -18932,7 +18932,7 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:local-id"
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
                             }
                         },
                         "switch": {

--- a/SWAGGER/tapi-oam.swagger
+++ b/SWAGGER/tapi-oam.swagger
@@ -1531,6 +1531,668 @@
                 }
             }
         },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/": {
             "get": {
                 "summary": "Retrieve connection-end-point",
@@ -18667,6 +19329,9 @@
                     "$ref": "#/definitions/termination-pac"
                 },
                 {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "string",
@@ -19448,6 +20113,14 @@
                                 "TERMINATION_STATE_UNKNOWN"
                             ],
                             "description": "Indicates whether the layer is terminated and if so how."
+                        },
+                        "total-potential-capacity": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "available-capacity": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
                         },
                         "connection-end-point": {
                             "type": "array",

--- a/SWAGGER/tapi-oam.swagger
+++ b/SWAGGER/tapi-oam.swagger
@@ -17327,7 +17327,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "meg-identifier": {
@@ -17442,7 +17443,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         }
                     }
@@ -17700,7 +17702,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
@@ -17893,7 +17896,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         }
                     }
@@ -17922,7 +17926,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "connectivity-service-end-point": {
@@ -18079,7 +18084,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         }
                     }
@@ -18105,7 +18111,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "service-interface-point": {
@@ -18336,7 +18343,8 @@
                         "OTU",
                         "ODU",
                         "ETH",
-                        "ETY"
+                        "ETY",
+                        "DSR"
                     ],
                     "description": "Indicate which layer this resilience parameters package configured for."
                 }
@@ -18412,7 +18420,8 @@
                             "OTU",
                             "ODU",
                             "ETH",
-                            "ETY"
+                            "ETY",
+                            "DSR"
                         ],
                         "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                     }
@@ -18504,7 +18513,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         },
@@ -18582,7 +18592,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -18622,7 +18633,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -18664,7 +18676,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "aggregated-node-edge-point": {
@@ -19097,7 +19110,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         }
                     }
@@ -19203,7 +19217,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         },

--- a/SWAGGER/tapi-oam.swagger
+++ b/SWAGGER/tapi-oam.swagger
@@ -16273,7 +16273,7 @@
                 }
             }
         },
-        "context": {
+        "tapi-context": {
             "allOf": [
                 {
                     "$ref": "#/definitions/global-class"
@@ -17883,7 +17883,7 @@
         "context_schema": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/context"
+                    "$ref": "#/definitions/tapi-context"
                 },
                 {
                     "properties": {

--- a/SWAGGER/tapi-oam.swagger
+++ b/SWAGGER/tapi-oam.swagger
@@ -10365,7 +10365,7 @@
                         "in": "body",
                         "name": "capacity",
                         "schema": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         },
                         "description": "capacitybody object",
                         "required": true
@@ -10410,7 +10410,7 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         }
                     },
                     "400": {
@@ -10447,7 +10447,7 @@
                         "in": "body",
                         "name": "capacity",
                         "schema": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         },
                         "description": "capacitybody object",
                         "required": true
@@ -10498,11 +10498,11 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_total-potential-capacity",
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-size/": {
+            "post": {
+                "summary": "Create total-size by ID",
+                "description": "Create operation of resource: total-size",
+                "operationId": "create_context_connectivity-service_end-point_capacity_total-size_total-size_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -10523,27 +10523,31 @@
                         "description": "ID of local_id",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "total-size",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/total-size/": {
+            },
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_total-size_total-size",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -10578,13 +10582,11 @@
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+            },
+            "put": {
+                "summary": "Update total-size by ID",
+                "description": "Update operation of resource: total-size",
+                "operationId": "update_context_connectivity-service_end-point_capacity_total-size_total-size_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -10605,256 +10607,56 @@
                         "description": "ID of local_id",
                         "required": true,
                         "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
                     },
                     {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
+                        "in": "body",
+                        "name": "total-size",
                         "schema": {
                             "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
                             "$ref": "#/definitions/capacity-value"
-                        }
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete total-size by ID",
+                "description": "Delete operation of resource: total-size",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -10862,11 +10664,55 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/": {
+            "post": {
+                "summary": "Create bandwidth-profile by ID",
+                "description": "Create operation of resource: bandwidth-profile",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -10900,13 +10746,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update bandwidth-profile by ID",
+                "description": "Update operation of resource: bandwidth-profile",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete bandwidth-profile by ID",
+                "description": "Delete operation of resource: bandwidth-profile",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/committed-information-rate/": {
+            "post": {
+                "summary": "Create committed-information-rate by ID",
+                "description": "Create operation of resource: committed-information-rate",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -10940,13 +10909,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-information-rate by ID",
+                "description": "Update operation of resource: committed-information-rate",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-information-rate by ID",
+                "description": "Delete operation of resource: committed-information-rate",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/committed-burst-size/": {
+            "post": {
+                "summary": "Create committed-burst-size by ID",
+                "description": "Create operation of resource: committed-burst-size",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -10980,13 +11072,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-burst-size by ID",
+                "description": "Update operation of resource: committed-burst-size",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-burst-size by ID",
+                "description": "Delete operation of resource: committed-burst-size",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/peak-information-rate/": {
+            "post": {
+                "summary": "Create peak-information-rate by ID",
+                "description": "Create operation of resource: peak-information-rate",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -11020,13 +11235,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update peak-information-rate by ID",
+                "description": "Update operation of resource: peak-information-rate",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-information-rate by ID",
+                "description": "Delete operation of resource: peak-information-rate",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/peak-burst-size/": {
+            "post": {
+                "summary": "Create peak-burst-size by ID",
+                "description": "Create operation of resource: peak-burst-size",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -11055,6 +11393,85 @@
                         "schema": {
                             "$ref": "#/definitions/capacity-value"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update peak-burst-size by ID",
+                "description": "Update operation of resource: peak-burst-size",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-burst-size by ID",
+                "description": "Delete operation of resource: peak-burst-size",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -11498,6 +11915,43 @@
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/": {
+            "post": {
+                "summary": "Create requested-capacity by ID",
+                "description": "Create operation of resource: requested-capacity",
+                "operationId": "create_context_connectivity-service_requested-capacity_requested-capacity_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "requested-capacity",
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "description": "requested-capacitybody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve requested-capacity",
                 "description": "Retrieve operation of resource: requested-capacity",
@@ -11528,9 +11982,112 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update requested-capacity by ID",
+                "description": "Update operation of resource: requested-capacity",
+                "operationId": "update_context_connectivity-service_requested-capacity_requested-capacity_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "requested-capacity",
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "description": "requested-capacitybody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete requested-capacity by ID",
+                "description": "Delete operation of resource: requested-capacity",
+                "operationId": "delete_context_connectivity-service_requested-capacity_requested-capacity_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/total-size/": {
+            "post": {
+                "summary": "Create total-size by ID",
+                "description": "Create operation of resource: total-size",
+                "operationId": "create_context_connectivity-service_requested-capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "total-size",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
@@ -11562,9 +12119,112 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update total-size by ID",
+                "description": "Update operation of resource: total-size",
+                "operationId": "update_context_connectivity-service_requested-capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "total-size",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete total-size by ID",
+                "description": "Delete operation of resource: total-size",
+                "operationId": "delete_context_connectivity-service_requested-capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/": {
+            "post": {
+                "summary": "Create bandwidth-profile by ID",
+                "description": "Create operation of resource: bandwidth-profile",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
@@ -11595,9 +12255,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update bandwidth-profile by ID",
+                "description": "Update operation of resource: bandwidth-profile",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete bandwidth-profile by ID",
+                "description": "Delete operation of resource: bandwidth-profile",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/committed-information-rate/": {
+            "post": {
+                "summary": "Create committed-information-rate by ID",
+                "description": "Create operation of resource: committed-information-rate",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
@@ -11628,9 +12390,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-information-rate by ID",
+                "description": "Update operation of resource: committed-information-rate",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-information-rate by ID",
+                "description": "Delete operation of resource: committed-information-rate",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/committed-burst-size/": {
+            "post": {
+                "summary": "Create committed-burst-size by ID",
+                "description": "Create operation of resource: committed-burst-size",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
@@ -11661,9 +12525,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-burst-size by ID",
+                "description": "Update operation of resource: committed-burst-size",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-burst-size by ID",
+                "description": "Delete operation of resource: committed-burst-size",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/peak-information-rate/": {
+            "post": {
+                "summary": "Create peak-information-rate by ID",
+                "description": "Create operation of resource: peak-information-rate",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
@@ -11694,9 +12660,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update peak-information-rate by ID",
+                "description": "Update operation of resource: peak-information-rate",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-information-rate by ID",
+                "description": "Delete operation of resource: peak-information-rate",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/peak-burst-size/": {
+            "post": {
+                "summary": "Create peak-burst-size by ID",
+                "description": "Create operation of resource: peak-burst-size",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
@@ -11722,6 +12790,71 @@
                         "schema": {
                             "$ref": "#/definitions/capacity-value"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update peak-burst-size by ID",
+                "description": "Update operation of resource: peak-burst-size",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-burst-size by ID",
+                "description": "Delete operation of resource: peak-burst-size",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -11902,6 +13035,50 @@
             }
         },
         "/config/context/connectivity-service/{uuid}/cost-characteristic/{cost_name}/": {
+            "post": {
+                "summary": "Create cost-characteristic by ID",
+                "description": "Create operation of resource: cost-characteristic",
+                "operationId": "create_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost_name",
+                        "description": "ID of cost_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "cost-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        },
+                        "description": "cost-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
@@ -11934,6 +13111,85 @@
                         "schema": {
                             "$ref": "#/definitions/cost-characteristic"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update cost-characteristic by ID",
+                "description": "Update operation of resource: cost-characteristic",
+                "operationId": "update_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost_name",
+                        "description": "ID of cost_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "cost-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        },
+                        "description": "cost-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete cost-characteristic by ID",
+                "description": "Delete operation of resource: cost-characteristic",
+                "operationId": "delete_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost_name",
+                        "description": "ID of cost_name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -11979,6 +13235,50 @@
             }
         },
         "/config/context/connectivity-service/{uuid}/latency-characteristic/{traffic_property_name}/": {
+            "post": {
+                "summary": "Create latency-characteristic by ID",
+                "description": "Create operation of resource: latency-characteristic",
+                "operationId": "create_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic_property_name",
+                        "description": "ID of traffic_property_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "latency-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        },
+                        "description": "latency-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
@@ -12011,6 +13311,85 @@
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update latency-characteristic by ID",
+                "description": "Update operation of resource: latency-characteristic",
+                "operationId": "update_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic_property_name",
+                        "description": "ID of traffic_property_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "latency-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        },
+                        "description": "latency-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete latency-characteristic by ID",
+                "description": "Delete operation of resource: latency-characteristic",
+                "operationId": "delete_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic_property_name",
+                        "description": "ID of traffic_property_name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -16734,7 +18113,7 @@
                             "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
                         },
                         "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         },
                         "direction": {
                             "type": "string",

--- a/SWAGGER/tapi-odu.swagger
+++ b/SWAGGER/tapi-odu.swagger
@@ -2768,11 +2768,284 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/accepted-payload-type/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/odu-common/": {
+            "post": {
+                "summary": "Create odu-common by ID",
+                "description": "Create operation of resource: odu-common",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_odu-common_odu-common_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "odu-common",
+                        "schema": {
+                            "$ref": "#/definitions/odu-common-pac"
+                        },
+                        "description": "odu-commonbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve odu-common",
+                "description": "Retrieve operation of resource: odu-common",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_odu-common_odu-common",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-common-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update odu-common by ID",
+                "description": "Update operation of resource: odu-common",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_odu-common_odu-common_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "odu-common",
+                        "schema": {
+                            "$ref": "#/definitions/odu-common-pac"
+                        },
+                        "description": "odu-commonbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete odu-common by ID",
+                "description": "Delete operation of resource: odu-common",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_odu-common_odu-common_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/odu-term-and-adapter/": {
+            "get": {
+                "summary": "Retrieve odu-term-and-adapter",
+                "description": "Retrieve operation of resource: odu-term-and-adapter",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_odu-term-and-adapter_odu-term-and-adapter",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-termination-and-client-adaptation-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/odu-term-and-adapter/accepted-payload-type/": {
             "get": {
                 "summary": "Retrieve accepted-payload-type",
                 "description": "Retrieve operation of resource: accepted-payload-type",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_accepted-payload-type_accepted-payload-type",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_odu-term-and-adapter_accepted-payload-type_accepted-payload-type",
                 "produces": [
                     "application/json"
                 ],
@@ -2815,6 +3088,161 @@
                         "schema": {
                             "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Sink at the client layer of the ODUP/ODU[i]j or ODUP/ODUj-21 adaptation function. \nThis attribute is a 2-digit Hex code that indicates the new accepted payload type.\nValid values are defined in Table 15-8 of ITU-T Recommendation G.709 with one additional value UN_INTERPRETABLE.",
                             "$ref": "#/definitions/odu-payload-type"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/odu-ctp/": {
+            "get": {
+                "summary": "Retrieve odu-ctp",
+                "description": "Retrieve operation of resource: odu-ctp",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_odu-ctp_odu-ctp",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-ctp-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/odu-protection/": {
+            "get": {
+                "summary": "Retrieve odu-protection",
+                "description": "Retrieve operation of resource: odu-protection",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_odu-protection_odu-protection",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-protection-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/odu-pool/": {
+            "get": {
+                "summary": "Retrieve odu-pool",
+                "description": "Retrieve operation of resource: odu-pool",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_odu-pool_odu-pool",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-pool-pac"
                         }
                     },
                     "400": {
@@ -17167,11 +17595,91 @@
                 }
             }
         },
-        "/config/context/meg/{uuid}/mep/{local_id}/accepted-payload-type/": {
+        "/config/context/meg/{uuid}/mep/{local_id}/odu-common/": {
+            "get": {
+                "summary": "Retrieve odu-common",
+                "description": "Retrieve operation of resource: odu-common",
+                "operationId": "retrieve_context_meg_mep_odu-common_odu-common",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-common-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/meg/{uuid}/mep/{local_id}/odu-term-and-adapter/": {
+            "get": {
+                "summary": "Retrieve odu-term-and-adapter",
+                "description": "Retrieve operation of resource: odu-term-and-adapter",
+                "operationId": "retrieve_context_meg_mep_odu-term-and-adapter_odu-term-and-adapter",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-termination-and-client-adaptation-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/meg/{uuid}/mep/{local_id}/odu-term-and-adapter/accepted-payload-type/": {
             "get": {
                 "summary": "Retrieve accepted-payload-type",
                 "description": "Retrieve operation of resource: accepted-payload-type",
-                "operationId": "retrieve_context_meg_mep_accepted-payload-type_accepted-payload-type",
+                "operationId": "retrieve_context_meg_mep_odu-term-and-adapter_accepted-payload-type_accepted-payload-type",
                 "produces": [
                     "application/json"
                 ],
@@ -17200,6 +17708,86 @@
                         "schema": {
                             "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Sink at the client layer of the ODUP/ODU[i]j or ODUP/ODUj-21 adaptation function. \nThis attribute is a 2-digit Hex code that indicates the new accepted payload type.\nValid values are defined in Table 15-8 of ITU-T Recommendation G.709 with one additional value UN_INTERPRETABLE.",
                             "$ref": "#/definitions/odu-payload-type"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/meg/{uuid}/mep/{local_id}/odu-ctp/": {
+            "get": {
+                "summary": "Retrieve odu-ctp",
+                "description": "Retrieve operation of resource: odu-ctp",
+                "operationId": "retrieve_context_meg_mep_odu-ctp_odu-ctp",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-ctp-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/meg/{uuid}/mep/{local_id}/odu-protection/": {
+            "get": {
+                "summary": "Retrieve odu-protection",
+                "description": "Retrieve operation of resource: odu-protection",
+                "operationId": "retrieve_context_meg_mep_odu-protection_odu-protection",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-protection-pac"
                         }
                     },
                     "400": {
@@ -17376,11 +17964,51 @@
                 }
             }
         },
-        "/config/context/meg/{uuid}/mip/{local_id}/deg-thr/": {
+        "/config/context/meg/{uuid}/mip/{local_id}/odu-mip/": {
+            "get": {
+                "summary": "Retrieve odu-mip",
+                "description": "Retrieve operation of resource: odu-mip",
+                "operationId": "retrieve_context_meg_mip_odu-mip_odu-mip",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-mip-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/meg/{uuid}/mip/{local_id}/odu-mip/deg-thr/": {
             "get": {
                 "summary": "Retrieve deg-thr",
                 "description": "Retrieve operation of resource: deg-thr",
-                "operationId": "retrieve_context_meg_mip_deg-thr_deg-thr",
+                "operationId": "retrieve_context_meg_mip_odu-mip_deg-thr_deg-thr",
                 "produces": [
                     "application/json"
                 ],
@@ -17417,11 +18045,131 @@
                 }
             }
         },
-        "/config/context/meg/{uuid}/mip/{local_id}/uas/": {
+        "/config/context/meg/{uuid}/mip/{local_id}/odu-ncm/": {
+            "get": {
+                "summary": "Retrieve odu-ncm",
+                "description": "Retrieve operation of resource: odu-ncm",
+                "operationId": "retrieve_context_meg_mip_odu-ncm_odu-ncm",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-ncm-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/meg/{uuid}/mip/{local_id}/odu-tcm/": {
+            "get": {
+                "summary": "Retrieve odu-tcm",
+                "description": "Retrieve operation of resource: odu-tcm",
+                "operationId": "retrieve_context_meg_mip_odu-tcm_odu-tcm",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-tcm-mip-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/meg/{uuid}/mip/{local_id}/odu-pm/": {
+            "get": {
+                "summary": "Retrieve odu-pm",
+                "description": "Retrieve operation of resource: odu-pm",
+                "operationId": "retrieve_context_meg_mip_odu-pm_odu-pm",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-pm-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/meg/{uuid}/mip/{local_id}/odu-pm/uas/": {
             "get": {
                 "summary": "Retrieve uas",
                 "description": "Retrieve operation of resource: uas",
-                "operationId": "retrieve_context_meg_mip_uas_uas",
+                "operationId": "retrieve_context_meg_mip_odu-pm_uas_uas",
                 "produces": [
                     "application/json"
                 ],
@@ -17450,6 +18198,46 @@
                         "schema": {
                             "description": "UnAvailable Second",
                             "$ref": "#/definitions/uas-choice"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/meg/{uuid}/mip/{local_id}/odu-defect/": {
+            "get": {
+                "summary": "Retrieve odu-defect",
+                "description": "Retrieve operation of resource: odu-defect",
+                "operationId": "retrieve_context_meg_mip_odu-defect_odu-defect",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-defect-pac"
                         }
                     },
                     "400": {
@@ -18176,7 +18964,20 @@
             }
         },
         "odu-connection-end-point-spec": {
-            "$ref": "#/definitions/odu-protection-pac"
+            "properties": {
+                "odu-common": {
+                    "$ref": "#/definitions/odu-common-pac"
+                },
+                "odu-term-and-adapter": {
+                    "$ref": "#/definitions/odu-termination-and-client-adaptation-pac"
+                },
+                "odu-ctp": {
+                    "$ref": "#/definitions/odu-ctp-pac"
+                },
+                "odu-protection": {
+                    "$ref": "#/definitions/odu-protection-pac"
+                }
+            }
         },
         "odu-pool-pac": {
             "properties": {
@@ -18192,7 +18993,11 @@
             }
         },
         "odu-node-edge-point-spec": {
-            "$ref": "#/definitions/odu-pool-pac"
+            "properties": {
+                "odu-pool": {
+                    "$ref": "#/definitions/odu-pool-pac"
+                }
+            }
         },
         "odu-ctp-pac": {
             "description": "This Pac contains the attributes associated with the CTP\nIt is present only if the CEP contains a CTP",
@@ -18215,7 +19020,23 @@
             }
         },
         "odu-mep-spec": {
-            "$ref": "#/definitions/odu-pm-pac"
+            "properties": {
+                "odu-mep": {
+                    "$ref": "#/definitions/odu-mep-pac"
+                },
+                "odu-ncm": {
+                    "$ref": "#/definitions/odu-ncm-pac"
+                },
+                "odu-tcm": {
+                    "$ref": "#/definitions/odu-tcm-mep-pac"
+                },
+                "odu-defect": {
+                    "$ref": "#/definitions/odu-defect-pac"
+                },
+                "odu-pm": {
+                    "$ref": "#/definitions/odu-pm-pac"
+                }
+            }
         },
         "odu-protection-pac": {
             "properties": {
@@ -18317,7 +19138,23 @@
             ]
         },
         "odu-mip-spec": {
-            "$ref": "#/definitions/odu-defect-pac"
+            "properties": {
+                "odu-mip": {
+                    "$ref": "#/definitions/odu-mip-pac"
+                },
+                "odu-ncm": {
+                    "$ref": "#/definitions/odu-ncm-pac"
+                },
+                "odu-tcm": {
+                    "$ref": "#/definitions/odu-tcm-mip-pac"
+                },
+                "odu-pm": {
+                    "$ref": "#/definitions/odu-pm-pac"
+                },
+                "odu-defect": {
+                    "$ref": "#/definitions/odu-defect-pac"
+                }
+            }
         },
         "odu-mip-pac": {
             "properties": {
@@ -18981,14 +19818,8 @@
                                 "x-path": "/tapi-common:context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
                             }
                         },
-                        "client-capacity": {
-                            "type": "string"
-                        },
-                        "max-client-instances": {
-                            "type": "string"
-                        },
-                        "max-client-size": {
-                            "type": "string"
+                        "odu-pool": {
+                            "$ref": "#/definitions/odu-pool-pac"
                         }
                     }
                 }
@@ -19776,82 +20607,17 @@
                                 "x-path": "/tapi-common:context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
                             }
                         },
-                        "odu-type": {
-                            "type": "string",
-                            "enum": [
-                                "ODU0",
-                                "ODU1",
-                                "ODU2",
-                                "ODU2E",
-                                "ODU3",
-                                "ODU4",
-                                "ODU_FLEX",
-                                "ODU_CN"
-                            ],
-                            "description": "This attribute specifies the type of the ODU termination point."
+                        "odu-common": {
+                            "$ref": "#/definitions/odu-common-pac"
                         },
-                        "odu-rate": {
-                            "type": "string",
-                            "description": "This attribute indicates the rate of the ODU terminatino point. \nThis attribute is Set at create; i.e., once created it cannot be changed directly. \nIn case of resizable ODU flex, its value can be changed via HAO (not directly on the attribute). \n"
+                        "odu-term-and-adapter": {
+                            "$ref": "#/definitions/odu-termination-and-client-adaptation-pac"
                         },
-                        "odu-rate-tolerance": {
-                            "type": "string",
-                            "description": "This attribute indicates the rate tolerance of the ODU termination point. \nValid values are real value in the unit of ppm. \nStandardized values are defined in Table 7-2/G.709."
+                        "odu-ctp": {
+                            "$ref": "#/definitions/odu-ctp-pac"
                         },
-                        "opu-tributary-slot-size": {
-                            "type": "string",
-                            "enum": [
-                                "1G25",
-                                "2G5"
-                            ],
-                            "description": "This attribute is applicable for ODU2 and ODU3 CTP only. It indicates the slot size of the ODU CTP."
-                        },
-                        "auto-payload-type": {
-                            "type": "boolean",
-                            "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUP/ODUj-21 adaptation function. The value of true of this attribute configures that the adaptation source function shall fall back to the payload type PT=20 if the conditions specified in 14.3.10.1/G.798 are satisfied. "
-                        },
-                        "configured-client-type": {
-                            "type": "string",
-                            "description": "This attribute configures the type of the client CTP of the server ODU TTP."
-                        },
-                        "configured-mapping-type": {
-                            "type": "string",
-                            "enum": [
-                                "AMP",
-                                "BMP",
-                                "GFP-F",
-                                "GMP",
-                                "TTP_GFP_BMP",
-                                "NULL"
-                            ],
-                            "description": "This attributes indicates the configured mapping type."
-                        },
-                        "accepted-payload-type": {
-                            "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Sink at the client layer of the ODUP/ODU[i]j or ODUP/ODUj-21 adaptation function. \nThis attribute is a 2-digit Hex code that indicates the new accepted payload type.\nValid values are defined in Table 15-8 of ITU-T Recommendation G.709 with one additional value UN_INTERPRETABLE.",
-                            "$ref": "#/definitions/odu-payload-type"
-                        },
-                        "tributary-slot-list": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "description": "This attribute contains a set of distinct (i.e. unique) integers (e.g. 2, 3, 5, 9, 15 representing the tributary slots TS2, TS3, TS5, TS9 and TS15) which represents the resources occupied by the Low Order ODU Link Connection (e.g. carrying an ODUflex with a bit rate of 6.25G). \nThis attribute applies when the LO ODU_ ConnectionTerminationPoint connects with an HO ODU_TrailTerminationPoint object. \nIt will not apply if this ODU_ ConnectionTerminationPoint object directly connects to an OTU_TrailTerminationPoint object (i.e. OTU has no trib slots). \nThe upper bound of the integer allowed in this set is a function of the HO-ODU server layer to which the ODU connection has been mapped (adapted). \nThus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). Note that the value of this attribute can be changed only in the case of ODUflex and has to be through specific operations (i.e. not be changing the attribute tributarySlotList directly)."
-                            }
-                        },
-                        "tributary-port-number": {
-                            "type": "string",
-                            "description": "This attribute identifies the tributary port number that is associated with the ODU CTP.\nrange of type : The value range depends on the size of the Tributary Port Number (TPN) field used which depends on th server-layer ODU or OTU.\nIn case of ODUk mapping into OTUk, there is no TPN field, so the tributaryPortNumber shall be zero.\nIn case of LO ODUj mapping over ODU1, ODU2 or ODU3, the TPN is encoded in a 6-bit field so the value range is 0-63. See clause 14.4.1/G.709-2016.\nIn case of LO ODUj mapping over ODU4, the TPN is encoded in a 7-bit field so the value range is 0-127. See clause 14.4.1.4/G.709-2016.\nIn case of ODUk mapping over ODUCn, the TPN is encoded in a 14-bit field so the value range is 0-16383. See clause 20.4.1.1/G.709-2016.\n"
-                        },
-                        "accepted-msi": {
-                            "type": "string",
-                            "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUP/ODUj-21 adaptation function. This attribute is a 1-byte field that represents the accepted multiplex structure of the adaptation function. "
-                        },
-                        "aps-enable": {
-                            "type": "boolean",
-                            "description": "This attribute is for enabling/disabling the automatic protection switching (APS) capability at the transport adaptation function that is represented by the ODU_ConnectionTerminationPoint object class. It triggers the MI_APS_EN signal to the transport adaptation function."
-                        },
-                        "aps-level": {
-                            "type": "string",
-                            "description": "This attribute is for configuring the automatic protection switching (APS) level that should operate at the transport adaptation function that is represented by the ODU_ConnectionTerminationPoint object class. It triggers the MI_APS_LVL signal to the transport adaptation function. The value 0 means path and the values 1 through 6 mean TCM level 1 through 6 respectively."
+                        "odu-protection": {
+                            "$ref": "#/definitions/odu-protection-pac"
                         }
                     }
                 }
@@ -20618,82 +21384,17 @@
                             },
                             "x-key": "value-name"
                         },
-                        "odu-type": {
-                            "type": "string",
-                            "enum": [
-                                "ODU0",
-                                "ODU1",
-                                "ODU2",
-                                "ODU2E",
-                                "ODU3",
-                                "ODU4",
-                                "ODU_FLEX",
-                                "ODU_CN"
-                            ],
-                            "description": "This attribute specifies the type of the ODU termination point."
+                        "odu-common": {
+                            "$ref": "#/definitions/odu-common-pac"
                         },
-                        "odu-rate": {
-                            "type": "string",
-                            "description": "This attribute indicates the rate of the ODU terminatino point. \nThis attribute is Set at create; i.e., once created it cannot be changed directly. \nIn case of resizable ODU flex, its value can be changed via HAO (not directly on the attribute). \n"
+                        "odu-term-and-adapter": {
+                            "$ref": "#/definitions/odu-termination-and-client-adaptation-pac"
                         },
-                        "odu-rate-tolerance": {
-                            "type": "string",
-                            "description": "This attribute indicates the rate tolerance of the ODU termination point. \nValid values are real value in the unit of ppm. \nStandardized values are defined in Table 7-2/G.709."
+                        "odu-ctp": {
+                            "$ref": "#/definitions/odu-ctp-pac"
                         },
-                        "opu-tributary-slot-size": {
-                            "type": "string",
-                            "enum": [
-                                "1G25",
-                                "2G5"
-                            ],
-                            "description": "This attribute is applicable for ODU2 and ODU3 CTP only. It indicates the slot size of the ODU CTP."
-                        },
-                        "auto-payload-type": {
-                            "type": "boolean",
-                            "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUP/ODUj-21 adaptation function. The value of true of this attribute configures that the adaptation source function shall fall back to the payload type PT=20 if the conditions specified in 14.3.10.1/G.798 are satisfied. "
-                        },
-                        "configured-client-type": {
-                            "type": "string",
-                            "description": "This attribute configures the type of the client CTP of the server ODU TTP."
-                        },
-                        "configured-mapping-type": {
-                            "type": "string",
-                            "enum": [
-                                "AMP",
-                                "BMP",
-                                "GFP-F",
-                                "GMP",
-                                "TTP_GFP_BMP",
-                                "NULL"
-                            ],
-                            "description": "This attributes indicates the configured mapping type."
-                        },
-                        "accepted-payload-type": {
-                            "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Sink at the client layer of the ODUP/ODU[i]j or ODUP/ODUj-21 adaptation function. \nThis attribute is a 2-digit Hex code that indicates the new accepted payload type.\nValid values are defined in Table 15-8 of ITU-T Recommendation G.709 with one additional value UN_INTERPRETABLE.",
-                            "$ref": "#/definitions/odu-payload-type"
-                        },
-                        "tributary-slot-list": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "description": "This attribute contains a set of distinct (i.e. unique) integers (e.g. 2, 3, 5, 9, 15 representing the tributary slots TS2, TS3, TS5, TS9 and TS15) which represents the resources occupied by the Low Order ODU Link Connection (e.g. carrying an ODUflex with a bit rate of 6.25G). \nThis attribute applies when the LO ODU_ ConnectionTerminationPoint connects with an HO ODU_TrailTerminationPoint object. \nIt will not apply if this ODU_ ConnectionTerminationPoint object directly connects to an OTU_TrailTerminationPoint object (i.e. OTU has no trib slots). \nThe upper bound of the integer allowed in this set is a function of the HO-ODU server layer to which the ODU connection has been mapped (adapted). \nThus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). Note that the value of this attribute can be changed only in the case of ODUflex and has to be through specific operations (i.e. not be changing the attribute tributarySlotList directly)."
-                            }
-                        },
-                        "tributary-port-number": {
-                            "type": "string",
-                            "description": "This attribute identifies the tributary port number that is associated with the ODU CTP.\nrange of type : The value range depends on the size of the Tributary Port Number (TPN) field used which depends on th server-layer ODU or OTU.\nIn case of ODUk mapping into OTUk, there is no TPN field, so the tributaryPortNumber shall be zero.\nIn case of LO ODUj mapping over ODU1, ODU2 or ODU3, the TPN is encoded in a 6-bit field so the value range is 0-63. See clause 14.4.1/G.709-2016.\nIn case of LO ODUj mapping over ODU4, the TPN is encoded in a 7-bit field so the value range is 0-127. See clause 14.4.1.4/G.709-2016.\nIn case of ODUk mapping over ODUCn, the TPN is encoded in a 14-bit field so the value range is 0-16383. See clause 20.4.1.1/G.709-2016.\n"
-                        },
-                        "accepted-msi": {
-                            "type": "string",
-                            "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUP/ODUj-21 adaptation function. This attribute is a 1-byte field that represents the accepted multiplex structure of the adaptation function. "
-                        },
-                        "aps-enable": {
-                            "type": "boolean",
-                            "description": "This attribute is for enabling/disabling the automatic protection switching (APS) capability at the transport adaptation function that is represented by the ODU_ConnectionTerminationPoint object class. It triggers the MI_APS_EN signal to the transport adaptation function."
-                        },
-                        "aps-level": {
-                            "type": "string",
-                            "description": "This attribute is for configuring the automatic protection switching (APS) level that should operate at the transport adaptation function that is represented by the ODU_ConnectionTerminationPoint object class. It triggers the MI_APS_LVL signal to the transport adaptation function. The value 0 means path and the values 1 through 6 mean TCM level 1 through 6 respectively."
+                        "odu-protection": {
+                            "$ref": "#/definitions/odu-protection-pac"
                         }
                     }
                 }
@@ -20717,94 +21418,20 @@
                             },
                             "x-key": "value-name"
                         },
-                        "acti": {
-                            "type": "string",
-                            "description": "The Trail Trace Identifier (TTI) information recovered (Accepted) from the TTI overhead position at the sink of a trail."
+                        "odu-mip": {
+                            "$ref": "#/definitions/odu-mip-pac"
                         },
-                        "ex-dapi": {
-                            "type": "string",
-                            "description": "The Expected Destination Access Point Identifier (ExDAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity."
+                        "odu-ncm": {
+                            "$ref": "#/definitions/odu-ncm-pac"
                         },
-                        "ex-sapi": {
-                            "type": "string",
-                            "description": "The Expected Source Access Point Identifier (ExSAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity.\n"
+                        "odu-tcm": {
+                            "$ref": "#/definitions/odu-tcm-mip-pac"
                         },
-                        "tim-act-disabled": {
-                            "type": "boolean",
-                            "description": "This attribute provides the control capability for the managing system to enable or disable the Consequent Action function when detecting Trace Identifier Mismatch (TIM) at the trail termination sink."
+                        "odu-pm": {
+                            "$ref": "#/definitions/odu-pm-pac"
                         },
-                        "tim-det-mode": {
-                            "type": "string",
-                            "enum": [
-                                "DAPI",
-                                "SAPI",
-                                "BOTH",
-                                "OFF"
-                            ],
-                            "description": "This attribute indicates the mode of the Trace Identifier Mismatch (TIM) Detection function allowed values: OFF, SAPIonly, DAPIonly, SAPIandDAPI"
-                        },
-                        "deg-m": {
-                            "type": "string",
-                            "description": "This attribute indicates the threshold level for declaring a Degraded Signal defect (dDEG). A dDEG shall be declared if DegM consecutive bad PM Seconds are detected."
-                        },
-                        "deg-thr": {
-                            "description": "This attribute indicates the threshold level for declaring a performance monitoring (PM) Second to be bad. The value of the threshold can be provisioned in terms of number of errored blocks or in terms of percentage of errored blocks. For percentage-based specification, in order to support provision of less than 1%, the specification consists of two fields. The first field indicates the granularity of percentage. For examples, in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple of the granularity. For number of errored block based, the value is a positive integer.",
-                            "$ref": "#/definitions/deg-thr"
-                        },
-                        "tcm-fields-in-use": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "description": "This attribute indicates the used TCM fields of the ODU OH."
-                            }
-                        },
-                        "tcm-field": {
-                            "type": "string",
-                            "description": "This attribute indicates the tandem connection monitoring field of the ODU OH."
-                        },
-                        "n-bbe": {
-                            "type": "string",
-                            "description": "Near-end Background Block Error"
-                        },
-                        "f-bbe": {
-                            "type": "string",
-                            "description": "Far-end Background Block Error"
-                        },
-                        "n-ses": {
-                            "type": "string",
-                            "description": "Near-end Severely Errored Second"
-                        },
-                        "f-ses": {
-                            "type": "string",
-                            "description": "Far-end Severely Errored Second"
-                        },
-                        "uas": {
-                            "description": "UnAvailable Second",
-                            "$ref": "#/definitions/uas-choice"
-                        },
-                        "bdi": {
-                            "type": "boolean",
-                            "description": "Backward Defect Indication"
-                        },
-                        "deg": {
-                            "type": "boolean",
-                            "description": "Signal Degraded"
-                        },
-                        "lck": {
-                            "type": "boolean",
-                            "description": "Locked"
-                        },
-                        "oci": {
-                            "type": "boolean",
-                            "description": "Open Connection Indicator"
-                        },
-                        "ssf": {
-                            "type": "boolean",
-                            "description": "Server Signal Failure"
-                        },
-                        "tim": {
-                            "type": "boolean",
-                            "description": "Trail Trace Identifier Mismatch"
+                        "odu-defect": {
+                            "$ref": "#/definitions/odu-defect-pac"
                         }
                     }
                 }

--- a/SWAGGER/tapi-odu.swagger
+++ b/SWAGGER/tapi-odu.swagger
@@ -14505,7 +14505,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/"
                             },
                             "type": "array"
                         }
@@ -14516,7 +14516,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/": {
             "get": {
                 "summary": "Retrieve switch-control by ID",
                 "description": "Retrieve operation of resource: switch-control",
@@ -14537,8 +14537,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -14556,7 +14556,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/": {
             "get": {
                 "summary": "Retrieve switch",
                 "description": "Retrieve operation of resource: switch",
@@ -14577,8 +14577,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -14589,7 +14589,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/"
                             },
                             "type": "array"
                         }
@@ -14600,7 +14600,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/": {
             "get": {
                 "summary": "Retrieve switch by ID",
                 "description": "Retrieve operation of resource: switch",
@@ -14621,8 +14621,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -14647,7 +14647,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/name/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/name/": {
             "get": {
                 "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
@@ -14668,8 +14668,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -14687,7 +14687,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/name/{value_name}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/name/{value_name}/"
                             },
                             "type": "array"
                         }
@@ -14698,7 +14698,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/name/{value_name}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/name/{value_name}/": {
             "get": {
                 "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
@@ -14719,8 +14719,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -14752,7 +14752,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/name/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
@@ -14773,8 +14773,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -14785,7 +14785,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/name/{value_name}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/name/{value_name}/"
                             },
                             "type": "array"
                         }
@@ -14796,7 +14796,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/name/{value_name}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/name/{value_name}/": {
             "get": {
                 "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
@@ -14817,8 +14817,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -14843,7 +14843,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/resilience-type/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/resilience-type/": {
             "get": {
                 "summary": "Retrieve resilience-type",
                 "description": "Retrieve operation of resource: resilience-type",
@@ -14864,8 +14864,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -19894,7 +19894,7 @@
                             "items": {
                                 "$ref": "#/definitions/switch-control"
                             },
-                            "x-key": "local-id"
+                            "x-key": "uuid"
                         },
                         "direction": {
                             "type": "string",
@@ -20275,7 +20275,7 @@
         "switch-control": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/local-class"
+                    "$ref": "#/definitions/resource-spec"
                 },
                 {
                     "$ref": "#/definitions/resilience-constraint"
@@ -20286,7 +20286,7 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:local-id"
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
                             }
                         },
                         "switch": {

--- a/SWAGGER/tapi-odu.swagger
+++ b/SWAGGER/tapi-odu.swagger
@@ -16487,7 +16487,7 @@
         "context_schema": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/context"
+                    "$ref": "#/definitions/tapi-context"
                 },
                 {
                     "properties": {
@@ -16658,7 +16658,7 @@
                 }
             }
         },
-        "context": {
+        "tapi-context": {
             "allOf": [
                 {
                     "$ref": "#/definitions/global-class"

--- a/SWAGGER/tapi-odu.swagger
+++ b/SWAGGER/tapi-odu.swagger
@@ -1531,6 +1531,668 @@
                 }
             }
         },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/": {
             "get": {
                 "summary": "Retrieve connection-end-point",
@@ -18290,6 +18952,14 @@
                             ],
                             "description": "Indicates whether the layer is terminated and if so how."
                         },
+                        "total-potential-capacity": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "available-capacity": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        },
                         "connection-end-point": {
                             "type": "array",
                             "items": {
@@ -18524,6 +19194,9 @@
                 },
                 {
                     "$ref": "#/definitions/termination-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
                 },
                 {
                     "properties": {

--- a/SWAGGER/tapi-odu.swagger
+++ b/SWAGGER/tapi-odu.swagger
@@ -18085,7 +18085,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
@@ -18371,7 +18372,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         },
@@ -18449,7 +18451,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -18489,7 +18492,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -18531,7 +18535,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "aggregated-node-edge-point": {
@@ -19234,7 +19239,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         }
                     }
@@ -19263,7 +19269,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "connectivity-service-end-point": {
@@ -19420,7 +19427,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         }
                     }
@@ -19446,7 +19454,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "service-interface-point": {
@@ -19677,7 +19686,8 @@
                         "OTU",
                         "ODU",
                         "ETH",
-                        "ETY"
+                        "ETY",
+                        "DSR"
                     ],
                     "description": "Indicate which layer this resilience parameters package configured for."
                 }
@@ -19753,7 +19763,8 @@
                             "OTU",
                             "ODU",
                             "ETH",
-                            "ETY"
+                            "ETY",
+                            "DSR"
                         ],
                         "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                     }

--- a/SWAGGER/tapi-odu.swagger
+++ b/SWAGGER/tapi-odu.swagger
@@ -10420,7 +10420,7 @@
                         "in": "body",
                         "name": "capacity",
                         "schema": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         },
                         "description": "capacitybody object",
                         "required": true
@@ -10465,7 +10465,7 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         }
                     },
                     "400": {
@@ -10502,7 +10502,7 @@
                         "in": "body",
                         "name": "capacity",
                         "schema": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         },
                         "description": "capacitybody object",
                         "required": true
@@ -10553,11 +10553,11 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_total-potential-capacity",
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-size/": {
+            "post": {
+                "summary": "Create total-size by ID",
+                "description": "Create operation of resource: total-size",
+                "operationId": "create_context_connectivity-service_end-point_capacity_total-size_total-size_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -10578,27 +10578,31 @@
                         "description": "ID of local_id",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "total-size",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/total-size/": {
+            },
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_total-size_total-size",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -10633,13 +10637,11 @@
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+            },
+            "put": {
+                "summary": "Update total-size by ID",
+                "description": "Update operation of resource: total-size",
+                "operationId": "update_context_connectivity-service_end-point_capacity_total-size_total-size_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -10660,256 +10662,56 @@
                         "description": "ID of local_id",
                         "required": true,
                         "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
                     },
                     {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
+                        "in": "body",
+                        "name": "total-size",
                         "schema": {
                             "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
                             "$ref": "#/definitions/capacity-value"
-                        }
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete total-size by ID",
+                "description": "Delete operation of resource: total-size",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -10917,11 +10719,55 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/": {
+            "post": {
+                "summary": "Create bandwidth-profile by ID",
+                "description": "Create operation of resource: bandwidth-profile",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -10955,13 +10801,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update bandwidth-profile by ID",
+                "description": "Update operation of resource: bandwidth-profile",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete bandwidth-profile by ID",
+                "description": "Delete operation of resource: bandwidth-profile",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/committed-information-rate/": {
+            "post": {
+                "summary": "Create committed-information-rate by ID",
+                "description": "Create operation of resource: committed-information-rate",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -10995,13 +10964,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-information-rate by ID",
+                "description": "Update operation of resource: committed-information-rate",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-information-rate by ID",
+                "description": "Delete operation of resource: committed-information-rate",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/committed-burst-size/": {
+            "post": {
+                "summary": "Create committed-burst-size by ID",
+                "description": "Create operation of resource: committed-burst-size",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -11035,13 +11127,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-burst-size by ID",
+                "description": "Update operation of resource: committed-burst-size",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-burst-size by ID",
+                "description": "Delete operation of resource: committed-burst-size",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/peak-information-rate/": {
+            "post": {
+                "summary": "Create peak-information-rate by ID",
+                "description": "Create operation of resource: peak-information-rate",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -11075,13 +11290,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update peak-information-rate by ID",
+                "description": "Update operation of resource: peak-information-rate",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-information-rate by ID",
+                "description": "Delete operation of resource: peak-information-rate",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/peak-burst-size/": {
+            "post": {
+                "summary": "Create peak-burst-size by ID",
+                "description": "Create operation of resource: peak-burst-size",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -11110,6 +11448,85 @@
                         "schema": {
                             "$ref": "#/definitions/capacity-value"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update peak-burst-size by ID",
+                "description": "Update operation of resource: peak-burst-size",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-burst-size by ID",
+                "description": "Delete operation of resource: peak-burst-size",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -11553,6 +11970,43 @@
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/": {
+            "post": {
+                "summary": "Create requested-capacity by ID",
+                "description": "Create operation of resource: requested-capacity",
+                "operationId": "create_context_connectivity-service_requested-capacity_requested-capacity_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "requested-capacity",
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "description": "requested-capacitybody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve requested-capacity",
                 "description": "Retrieve operation of resource: requested-capacity",
@@ -11583,9 +12037,112 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update requested-capacity by ID",
+                "description": "Update operation of resource: requested-capacity",
+                "operationId": "update_context_connectivity-service_requested-capacity_requested-capacity_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "requested-capacity",
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "description": "requested-capacitybody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete requested-capacity by ID",
+                "description": "Delete operation of resource: requested-capacity",
+                "operationId": "delete_context_connectivity-service_requested-capacity_requested-capacity_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/total-size/": {
+            "post": {
+                "summary": "Create total-size by ID",
+                "description": "Create operation of resource: total-size",
+                "operationId": "create_context_connectivity-service_requested-capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "total-size",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
@@ -11617,9 +12174,112 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update total-size by ID",
+                "description": "Update operation of resource: total-size",
+                "operationId": "update_context_connectivity-service_requested-capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "total-size",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete total-size by ID",
+                "description": "Delete operation of resource: total-size",
+                "operationId": "delete_context_connectivity-service_requested-capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/": {
+            "post": {
+                "summary": "Create bandwidth-profile by ID",
+                "description": "Create operation of resource: bandwidth-profile",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
@@ -11650,9 +12310,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update bandwidth-profile by ID",
+                "description": "Update operation of resource: bandwidth-profile",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete bandwidth-profile by ID",
+                "description": "Delete operation of resource: bandwidth-profile",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/committed-information-rate/": {
+            "post": {
+                "summary": "Create committed-information-rate by ID",
+                "description": "Create operation of resource: committed-information-rate",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
@@ -11683,9 +12445,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-information-rate by ID",
+                "description": "Update operation of resource: committed-information-rate",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-information-rate by ID",
+                "description": "Delete operation of resource: committed-information-rate",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/committed-burst-size/": {
+            "post": {
+                "summary": "Create committed-burst-size by ID",
+                "description": "Create operation of resource: committed-burst-size",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
@@ -11716,9 +12580,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-burst-size by ID",
+                "description": "Update operation of resource: committed-burst-size",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-burst-size by ID",
+                "description": "Delete operation of resource: committed-burst-size",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/peak-information-rate/": {
+            "post": {
+                "summary": "Create peak-information-rate by ID",
+                "description": "Create operation of resource: peak-information-rate",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
@@ -11749,9 +12715,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update peak-information-rate by ID",
+                "description": "Update operation of resource: peak-information-rate",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-information-rate by ID",
+                "description": "Delete operation of resource: peak-information-rate",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/peak-burst-size/": {
+            "post": {
+                "summary": "Create peak-burst-size by ID",
+                "description": "Create operation of resource: peak-burst-size",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
@@ -11777,6 +12845,71 @@
                         "schema": {
                             "$ref": "#/definitions/capacity-value"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update peak-burst-size by ID",
+                "description": "Update operation of resource: peak-burst-size",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-burst-size by ID",
+                "description": "Delete operation of resource: peak-burst-size",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -11957,6 +13090,50 @@
             }
         },
         "/config/context/connectivity-service/{uuid}/cost-characteristic/{cost_name}/": {
+            "post": {
+                "summary": "Create cost-characteristic by ID",
+                "description": "Create operation of resource: cost-characteristic",
+                "operationId": "create_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost_name",
+                        "description": "ID of cost_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "cost-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        },
+                        "description": "cost-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
@@ -11989,6 +13166,85 @@
                         "schema": {
                             "$ref": "#/definitions/cost-characteristic"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update cost-characteristic by ID",
+                "description": "Update operation of resource: cost-characteristic",
+                "operationId": "update_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost_name",
+                        "description": "ID of cost_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "cost-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        },
+                        "description": "cost-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete cost-characteristic by ID",
+                "description": "Delete operation of resource: cost-characteristic",
+                "operationId": "delete_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost_name",
+                        "description": "ID of cost_name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -12034,6 +13290,50 @@
             }
         },
         "/config/context/connectivity-service/{uuid}/latency-characteristic/{traffic_property_name}/": {
+            "post": {
+                "summary": "Create latency-characteristic by ID",
+                "description": "Create operation of resource: latency-characteristic",
+                "operationId": "create_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic_property_name",
+                        "description": "ID of traffic_property_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "latency-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        },
+                        "description": "latency-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
@@ -12066,6 +13366,85 @@
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update latency-characteristic by ID",
+                "description": "Update operation of resource: latency-characteristic",
+                "operationId": "update_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic_property_name",
+                        "description": "ID of traffic_property_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "latency-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        },
+                        "description": "latency-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete latency-characteristic by ID",
+                "description": "Delete operation of resource: latency-characteristic",
+                "operationId": "delete_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic_property_name",
+                        "description": "ID of traffic_property_name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -18075,7 +19454,7 @@
                             "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
                         },
                         "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         },
                         "direction": {
                             "type": "string",

--- a/SWAGGER/tapi-otsi.swagger
+++ b/SWAGGER/tapi-otsi.swagger
@@ -1531,6 +1531,668 @@
                 }
             }
         },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/": {
             "get": {
                 "summary": "Retrieve connection-end-point",
@@ -15504,6 +16166,14 @@
                             ],
                             "description": "Indicates whether the layer is terminated and if so how."
                         },
+                        "total-potential-capacity": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "available-capacity": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        },
                         "connection-end-point": {
                             "type": "array",
                             "items": {
@@ -15825,6 +16495,9 @@
                 },
                 {
                     "$ref": "#/definitions/termination-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
                 },
                 {
                     "properties": {

--- a/SWAGGER/tapi-otsi.swagger
+++ b/SWAGGER/tapi-otsi.swagger
@@ -13681,7 +13681,7 @@
         "context_schema": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/context"
+                    "$ref": "#/definitions/tapi-context"
                 },
                 {
                     "properties": {
@@ -13838,7 +13838,7 @@
                 }
             }
         },
-        "context": {
+        "tapi-context": {
             "allOf": [
                 {
                     "$ref": "#/definitions/global-class"

--- a/SWAGGER/tapi-otsi.swagger
+++ b/SWAGGER/tapi-otsi.swagger
@@ -14665,7 +14665,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/"
                             },
                             "type": "array"
                         }
@@ -14676,7 +14676,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/": {
             "get": {
                 "summary": "Retrieve switch-control by ID",
                 "description": "Retrieve operation of resource: switch-control",
@@ -14697,8 +14697,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -14716,7 +14716,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/": {
             "get": {
                 "summary": "Retrieve switch",
                 "description": "Retrieve operation of resource: switch",
@@ -14737,8 +14737,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -14749,7 +14749,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/"
                             },
                             "type": "array"
                         }
@@ -14760,7 +14760,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/": {
             "get": {
                 "summary": "Retrieve switch by ID",
                 "description": "Retrieve operation of resource: switch",
@@ -14781,8 +14781,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -14807,7 +14807,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/name/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/name/": {
             "get": {
                 "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
@@ -14828,8 +14828,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -14847,7 +14847,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/name/{value_name}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/name/{value_name}/"
                             },
                             "type": "array"
                         }
@@ -14858,7 +14858,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/switch/{local_id}/name/{value_name}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/switch/{local_id}/name/{value_name}/": {
             "get": {
                 "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
@@ -14879,8 +14879,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -14912,7 +14912,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/name/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
@@ -14933,8 +14933,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -14945,7 +14945,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local_id}/name/{value_name}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{switch_control_uuid}/name/{value_name}/"
                             },
                             "type": "array"
                         }
@@ -14956,7 +14956,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/name/{value_name}/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/name/{value_name}/": {
             "get": {
                 "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
@@ -14977,8 +14977,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -15003,7 +15003,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local_id}/resilience-type/": {
+        "/config/context/connection/{uuid}/switch-control/{switch_control_uuid}/resilience-type/": {
             "get": {
                 "summary": "Retrieve resilience-type",
                 "description": "Retrieve operation of resource: resilience-type",
@@ -15024,8 +15024,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
+                        "name": "switch_control_uuid",
+                        "description": "ID of switch_control_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -17026,7 +17026,7 @@
                             "items": {
                                 "$ref": "#/definitions/switch-control"
                             },
-                            "x-key": "local-id"
+                            "x-key": "uuid"
                         },
                         "direction": {
                             "type": "string",
@@ -17407,7 +17407,7 @@
         "switch-control": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/local-class"
+                    "$ref": "#/definitions/resource-spec"
                 },
                 {
                     "$ref": "#/definitions/resilience-constraint"
@@ -17418,7 +17418,7 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:local-id"
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid"
                             }
                         },
                         "switch": {

--- a/SWAGGER/tapi-otsi.swagger
+++ b/SWAGGER/tapi-otsi.swagger
@@ -2417,11 +2417,119 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/selected-nominal-central-frequency/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/otsi-adapter/": {
+            "get": {
+                "summary": "Retrieve otsi-adapter",
+                "description": "Retrieve operation of resource: otsi-adapter",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-adapter_otsi-adapter",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/otsi-client-adaptation-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/otsi-termination/": {
+            "get": {
+                "summary": "Retrieve otsi-termination",
+                "description": "Retrieve operation of resource: otsi-termination",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-termination_otsi-termination",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/otsi-termination-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/otsi-termination/selected-nominal-central-frequency/": {
             "get": {
                 "summary": "Retrieve selected-nominal-central-frequency",
                 "description": "Retrieve operation of resource: selected-nominal-central-frequency",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_selected-nominal-central-frequency_selected-nominal-central-frequency",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-termination_selected-nominal-central-frequency_selected-nominal-central-frequency",
                 "produces": [
                     "application/json"
                 ],
@@ -2471,11 +2579,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/supportable-lower-nominal-central-frequency/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/otsi-termination/supportable-lower-nominal-central-frequency/": {
             "get": {
                 "summary": "Retrieve supportable-lower-nominal-central-frequency",
                 "description": "Retrieve operation of resource: supportable-lower-nominal-central-frequency",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_supportable-lower-nominal-central-frequency_supportable-lower-nominal-central-frequency",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-termination_supportable-lower-nominal-central-frequency_supportable-lower-nominal-central-frequency",
                 "produces": [
                     "application/json"
                 ],
@@ -2525,11 +2633,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/supportable-upper-nominal-central-frequency/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/otsi-termination/supportable-upper-nominal-central-frequency/": {
             "get": {
                 "summary": "Retrieve supportable-upper-nominal-central-frequency",
                 "description": "Retrieve operation of resource: supportable-upper-nominal-central-frequency",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_supportable-upper-nominal-central-frequency_supportable-upper-nominal-central-frequency",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-termination_supportable-upper-nominal-central-frequency_supportable-upper-nominal-central-frequency",
                 "produces": [
                     "application/json"
                 ],
@@ -2579,11 +2687,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/selected-application-identifier/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/otsi-termination/selected-application-identifier/": {
             "get": {
                 "summary": "Retrieve selected-application-identifier",
                 "description": "Retrieve operation of resource: selected-application-identifier",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_selected-application-identifier_selected-application-identifier",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-termination_selected-application-identifier_selected-application-identifier",
                 "produces": [
                     "application/json"
                 ],
@@ -2633,11 +2741,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/supportable-application-identifier/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/otsi-termination/supportable-application-identifier/": {
             "get": {
                 "summary": "Retrieve supportable-application-identifier",
                 "description": "Retrieve operation of resource: supportable-application-identifier",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_supportable-application-identifier_supportable-application-identifier",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-termination_supportable-application-identifier_supportable-application-identifier",
                 "produces": [
                     "application/json"
                 ],
@@ -2687,11 +2795,65 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/selected-frequency-slot/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/otsi-ctp/": {
+            "get": {
+                "summary": "Retrieve otsi-ctp",
+                "description": "Retrieve operation of resource: otsi-ctp",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-ctp_otsi-ctp",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection_end_point_uuid",
+                        "description": "ID of connection_end_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/otsi-ctp-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/otsi-ctp/selected-frequency-slot/": {
             "get": {
                 "summary": "Retrieve selected-frequency-slot",
                 "description": "Retrieve operation of resource: selected-frequency-slot",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_selected-frequency-slot_selected-frequency-slot",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-ctp_selected-frequency-slot_selected-frequency-slot",
                 "produces": [
                     "application/json"
                 ],
@@ -2741,11 +2903,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/selected-frequency-slot/nominal-central-frequency/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/connection-end-point/{connection_end_point_uuid}/otsi-ctp/selected-frequency-slot/nominal-central-frequency/": {
             "get": {
                 "summary": "Retrieve nominal-central-frequency",
                 "description": "Retrieve operation of resource: nominal-central-frequency",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_selected-frequency-slot_nominal-central-frequency_nominal-central-frequency",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-ctp_selected-frequency-slot_nominal-central-frequency_nominal-central-frequency",
                 "produces": [
                     "application/json"
                 ],
@@ -2795,11 +2957,58 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-frequency-slot/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/otsi-pool/": {
+            "get": {
+                "summary": "Retrieve otsi-pool",
+                "description": "Retrieve operation of resource: otsi-pool",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_otsi-pool_otsi-pool",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/otsi-pool-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/otsi-pool/available-frequency-slot/": {
             "get": {
                 "summary": "Retrieve available-frequency-slot",
                 "description": "Retrieve operation of resource: available-frequency-slot",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-frequency-slot_available-frequency-slot",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_otsi-pool_available-frequency-slot_available-frequency-slot",
                 "produces": [
                     "application/json"
                 ],
@@ -2842,11 +3051,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-frequency-slot/nominal-central-frequency/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/otsi-pool/available-frequency-slot/nominal-central-frequency/": {
             "get": {
                 "summary": "Retrieve nominal-central-frequency",
                 "description": "Retrieve operation of resource: nominal-central-frequency",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-frequency-slot_nominal-central-frequency_nominal-central-frequency",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_otsi-pool_available-frequency-slot_nominal-central-frequency_nominal-central-frequency",
                 "produces": [
                     "application/json"
                 ],
@@ -2889,11 +3098,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/occupied-frequency-slot/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/otsi-pool/occupied-frequency-slot/": {
             "get": {
                 "summary": "Retrieve occupied-frequency-slot",
                 "description": "Retrieve operation of resource: occupied-frequency-slot",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_occupied-frequency-slot_occupied-frequency-slot",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_otsi-pool_occupied-frequency-slot_occupied-frequency-slot",
                 "produces": [
                     "application/json"
                 ],
@@ -2936,11 +3145,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/occupied-frequency-slot/nominal-central-frequency/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/otsi-pool/occupied-frequency-slot/nominal-central-frequency/": {
             "get": {
                 "summary": "Retrieve nominal-central-frequency",
                 "description": "Retrieve operation of resource: nominal-central-frequency",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_occupied-frequency-slot_nominal-central-frequency_nominal-central-frequency",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_otsi-pool_occupied-frequency-slot_nominal-central-frequency_nominal-central-frequency",
                 "produces": [
                     "application/json"
                 ],
@@ -15576,9 +15785,19 @@
         }
     },
     "definitions": {
-        "otsi-a-client-adaptation-pac": {},
+        "otsi-client-adaptation-pac": {},
         "otsi-connection-end-point-spec": {
-            "$ref": "#/definitions/otsi-g-ctp-pac"
+            "properties": {
+                "otsi-adapter": {
+                    "$ref": "#/definitions/otsi-client-adaptation-pac"
+                },
+                "otsi-termination": {
+                    "$ref": "#/definitions/otsi-termination-pac"
+                },
+                "otsi-ctp": {
+                    "$ref": "#/definitions/otsi-ctp-pac"
+                }
+            }
         },
         "otsi-termination-pac": {
             "properties": {
@@ -15616,7 +15835,7 @@
                 }
             }
         },
-        "otsi-a-pool-pac": {
+        "otsi-pool-pac": {
             "properties": {
                 "available-frequency-slot": {
                     "type": "array",
@@ -15633,7 +15852,11 @@
             }
         },
         "otsi-node-edge-point-spec": {
-            "$ref": "#/definitions/otsi-a-pool-pac"
+            "properties": {
+                "otsi-pool": {
+                    "$ref": "#/definitions/otsi-pool-pac"
+                }
+            }
         },
         "otsi-routing-spec": {
             "properties": {
@@ -15649,7 +15872,7 @@
                 }
             }
         },
-        "otsi-g-ctp-pac": {
+        "otsi-ctp-pac": {
             "properties": {
                 "selected-frequency-slot": {
                     "type": "array",
@@ -16235,43 +16458,14 @@
                                                 ],
                                                 "description": "Indicates whether the layer is terminated and if so how."
                                             },
-                                            "selected-nominal-central-frequency": {
-                                                "description": "This attribute indicates the nominal central frequency or wavelength of the optical channel associated with the OCh Trail Termination function. The value of this attribute is a pair {LinkType, Integer}, in which LinkType is DWDM, or CWDM, or NO_WDM. When LinkType is DWDM, the integer represents the nominal central frequency in unit of MHz. When LinkType is CWDM, the integer represents the nominal central wavelength in unit of pm (picometer). When LinkType is NO_WDM, the Integer field is null. For frequency and wavelength, the value shall be within the range of the maximum and minimum central frequencies or wavelengths specified for the corresponding application code used at the OCh Trail Termination.\nThis attribute is required for the OCh Trial Termination Point Source at the transmitter.  For the OCh Trail Termination Point Sink at the receiver, this attribute may not be needed since the receiver is required to operate at any frequency/wavelength between the maximum and minimum range for the standard application code.\n",
-                                                "type": "array",
-                                                "items": {
-                                                    "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
-                                                }
+                                            "otsi-adapter": {
+                                                "$ref": "#/definitions/otsi-client-adaptation-pac"
                                             },
-                                            "supportable-lower-nominal-central-frequency": {
-                                                "type": "array",
-                                                "items": {
-                                                    "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
-                                                }
+                                            "otsi-termination": {
+                                                "$ref": "#/definitions/otsi-termination-pac"
                                             },
-                                            "supportable-upper-nominal-central-frequency": {
-                                                "type": "array",
-                                                "items": {
-                                                    "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
-                                                }
-                                            },
-                                            "selected-application-identifier": {
-                                                "description": "This attribute indicates the selected Application Identifier that is used by the OCh trail termination function. The syntax of ApplicationIdentifier is a pair {ApplicationIdentifierType, PrintableString}. The value of ApplicationIdentifierType is either STANDARD or PROPRIETARY. The value of PrintableString represents the standard application code as defined in the ITU-T Recommendations or a vendor-specific proprietary code. If the ApplicationIdentifierType is STANDARD the value of PrintableString represents a standard application code as defined in the ITU-T Recommendations. If the ApplicationIdentifierType is PROPRIETARY, the first six characters of the PrintableString must contain the Hexadecimal representation of an OUI assigned to the vendor whose implementation generated the Application Identifier; the remaining octets of the PrintableString are unspecified. The value of this attribute of an object instance has to be one of the values identified in the attribute SupportableApplicationIdentifierList of the same object instance. The values and value ranges of the optical interface parameters of a standard application code must be consistent with those values specified in the ITU-T Recommendation for that application code.",
-                                                "type": "array",
-                                                "items": {
-                                                    "$ref": "#/definitions/application-identifier"
-                                                }
-                                            },
-                                            "supportable-application-identifier": {
-                                                "type": "array",
-                                                "items": {
-                                                    "$ref": "#/definitions/application-identifier"
-                                                }
-                                            },
-                                            "selected-frequency-slot": {
-                                                "type": "array",
-                                                "items": {
-                                                    "$ref": "#/definitions/frequency-slot"
-                                                }
+                                            "otsi-ctp": {
+                                                "$ref": "#/definitions/otsi-ctp-pac"
                                             }
                                         }
                                     }
@@ -16279,17 +16473,8 @@
                             },
                             "x-key": "uuid"
                         },
-                        "available-frequency-slot": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/frequency-slot"
-                            }
-                        },
-                        "occupied-frequency-slot": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/frequency-slot"
-                            }
+                        "otsi-pool": {
+                            "$ref": "#/definitions/otsi-pool-pac"
                         }
                     }
                 }
@@ -16947,43 +17132,14 @@
                             ],
                             "description": "Indicates whether the layer is terminated and if so how."
                         },
-                        "selected-nominal-central-frequency": {
-                            "description": "This attribute indicates the nominal central frequency or wavelength of the optical channel associated with the OCh Trail Termination function. The value of this attribute is a pair {LinkType, Integer}, in which LinkType is DWDM, or CWDM, or NO_WDM. When LinkType is DWDM, the integer represents the nominal central frequency in unit of MHz. When LinkType is CWDM, the integer represents the nominal central wavelength in unit of pm (picometer). When LinkType is NO_WDM, the Integer field is null. For frequency and wavelength, the value shall be within the range of the maximum and minimum central frequencies or wavelengths specified for the corresponding application code used at the OCh Trail Termination.\nThis attribute is required for the OCh Trial Termination Point Source at the transmitter.  For the OCh Trail Termination Point Sink at the receiver, this attribute may not be needed since the receiver is required to operate at any frequency/wavelength between the maximum and minimum range for the standard application code.\n",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
-                            }
+                        "otsi-adapter": {
+                            "$ref": "#/definitions/otsi-client-adaptation-pac"
                         },
-                        "supportable-lower-nominal-central-frequency": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
-                            }
+                        "otsi-termination": {
+                            "$ref": "#/definitions/otsi-termination-pac"
                         },
-                        "supportable-upper-nominal-central-frequency": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
-                            }
-                        },
-                        "selected-application-identifier": {
-                            "description": "This attribute indicates the selected Application Identifier that is used by the OCh trail termination function. The syntax of ApplicationIdentifier is a pair {ApplicationIdentifierType, PrintableString}. The value of ApplicationIdentifierType is either STANDARD or PROPRIETARY. The value of PrintableString represents the standard application code as defined in the ITU-T Recommendations or a vendor-specific proprietary code. If the ApplicationIdentifierType is STANDARD the value of PrintableString represents a standard application code as defined in the ITU-T Recommendations. If the ApplicationIdentifierType is PROPRIETARY, the first six characters of the PrintableString must contain the Hexadecimal representation of an OUI assigned to the vendor whose implementation generated the Application Identifier; the remaining octets of the PrintableString are unspecified. The value of this attribute of an object instance has to be one of the values identified in the attribute SupportableApplicationIdentifierList of the same object instance. The values and value ranges of the optical interface parameters of a standard application code must be consistent with those values specified in the ITU-T Recommendation for that application code.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/application-identifier"
-                            }
-                        },
-                        "supportable-application-identifier": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/application-identifier"
-                            }
-                        },
-                        "selected-frequency-slot": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/frequency-slot"
-                            }
+                        "otsi-ctp": {
+                            "$ref": "#/definitions/otsi-ctp-pac"
                         }
                     }
                 }

--- a/SWAGGER/tapi-otsi.swagger
+++ b/SWAGGER/tapi-otsi.swagger
@@ -10580,7 +10580,7 @@
                         "in": "body",
                         "name": "capacity",
                         "schema": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         },
                         "description": "capacitybody object",
                         "required": true
@@ -10625,7 +10625,7 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         }
                     },
                     "400": {
@@ -10662,7 +10662,7 @@
                         "in": "body",
                         "name": "capacity",
                         "schema": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         },
                         "description": "capacitybody object",
                         "required": true
@@ -10713,11 +10713,11 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_total-potential-capacity",
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-size/": {
+            "post": {
+                "summary": "Create total-size by ID",
+                "description": "Create operation of resource: total-size",
+                "operationId": "create_context_connectivity-service_end-point_capacity_total-size_total-size_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -10738,27 +10738,31 @@
                         "description": "ID of local_id",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "total-size",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/total-size/": {
+            },
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_total-size_total-size",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -10793,13 +10797,11 @@
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+            },
+            "put": {
+                "summary": "Update total-size by ID",
+                "description": "Update operation of resource: total-size",
+                "operationId": "update_context_connectivity-service_end-point_capacity_total-size_total-size_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -10820,256 +10822,56 @@
                         "description": "ID of local_id",
                         "required": true,
                         "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
                     },
                     {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local_id",
-                        "description": "ID of local_id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
+                        "in": "body",
+                        "name": "total-size",
                         "schema": {
                             "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
                             "$ref": "#/definitions/capacity-value"
-                        }
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete total-size by ID",
+                "description": "Delete operation of resource: total-size",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -11077,11 +10879,55 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/": {
+            "post": {
+                "summary": "Create bandwidth-profile by ID",
+                "description": "Create operation of resource: bandwidth-profile",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -11115,13 +10961,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update bandwidth-profile by ID",
+                "description": "Update operation of resource: bandwidth-profile",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete bandwidth-profile by ID",
+                "description": "Delete operation of resource: bandwidth-profile",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/committed-information-rate/": {
+            "post": {
+                "summary": "Create committed-information-rate by ID",
+                "description": "Create operation of resource: committed-information-rate",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -11155,13 +11124,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-information-rate by ID",
+                "description": "Update operation of resource: committed-information-rate",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-information-rate by ID",
+                "description": "Delete operation of resource: committed-information-rate",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/committed-burst-size/": {
+            "post": {
+                "summary": "Create committed-burst-size by ID",
+                "description": "Create operation of resource: committed-burst-size",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -11195,13 +11287,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-burst-size by ID",
+                "description": "Update operation of resource: committed-burst-size",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-burst-size by ID",
+                "description": "Delete operation of resource: committed-burst-size",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/peak-information-rate/": {
+            "post": {
+                "summary": "Create peak-information-rate by ID",
+                "description": "Create operation of resource: peak-information-rate",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -11235,13 +11450,136 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update peak-information-rate by ID",
+                "description": "Update operation of resource: peak-information-rate",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-information-rate by ID",
+                "description": "Delete operation of resource: peak-information-rate",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local_id}/capacity/bandwidth-profile/peak-burst-size/": {
+            "post": {
+                "summary": "Create peak-burst-size by ID",
+                "description": "Create operation of resource: peak-burst-size",
+                "operationId": "create_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_connectivity-service_end-point_capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -11270,6 +11608,85 @@
                         "schema": {
                             "$ref": "#/definitions/capacity-value"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update peak-burst-size by ID",
+                "description": "Update operation of resource: peak-burst-size",
+                "operationId": "update_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-burst-size by ID",
+                "description": "Delete operation of resource: peak-burst-size",
+                "operationId": "delete_context_connectivity-service_end-point_capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local_id",
+                        "description": "ID of local_id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -11713,6 +12130,43 @@
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/": {
+            "post": {
+                "summary": "Create requested-capacity by ID",
+                "description": "Create operation of resource: requested-capacity",
+                "operationId": "create_context_connectivity-service_requested-capacity_requested-capacity_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "requested-capacity",
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "description": "requested-capacitybody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve requested-capacity",
                 "description": "Retrieve operation of resource: requested-capacity",
@@ -11743,9 +12197,112 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update requested-capacity by ID",
+                "description": "Update operation of resource: requested-capacity",
+                "operationId": "update_context_connectivity-service_requested-capacity_requested-capacity_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "requested-capacity",
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "description": "requested-capacitybody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete requested-capacity by ID",
+                "description": "Delete operation of resource: requested-capacity",
+                "operationId": "delete_context_connectivity-service_requested-capacity_requested-capacity_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/total-size/": {
+            "post": {
+                "summary": "Create total-size by ID",
+                "description": "Create operation of resource: total-size",
+                "operationId": "create_context_connectivity-service_requested-capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "total-size",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
@@ -11777,9 +12334,112 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update total-size by ID",
+                "description": "Update operation of resource: total-size",
+                "operationId": "update_context_connectivity-service_requested-capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "total-size",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "total-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete total-size by ID",
+                "description": "Delete operation of resource: total-size",
+                "operationId": "delete_context_connectivity-service_requested-capacity_total-size_total-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/": {
+            "post": {
+                "summary": "Create bandwidth-profile by ID",
+                "description": "Create operation of resource: bandwidth-profile",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
@@ -11810,9 +12470,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update bandwidth-profile by ID",
+                "description": "Update operation of resource: bandwidth-profile",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "bandwidth-profile",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        },
+                        "description": "bandwidth-profilebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete bandwidth-profile by ID",
+                "description": "Delete operation of resource: bandwidth-profile",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/committed-information-rate/": {
+            "post": {
+                "summary": "Create committed-information-rate by ID",
+                "description": "Create operation of resource: committed-information-rate",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
@@ -11843,9 +12605,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-information-rate by ID",
+                "description": "Update operation of resource: committed-information-rate",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-information-rate by ID",
+                "description": "Delete operation of resource: committed-information-rate",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/committed-burst-size/": {
+            "post": {
+                "summary": "Create committed-burst-size by ID",
+                "description": "Create operation of resource: committed-burst-size",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
@@ -11876,9 +12740,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update committed-burst-size by ID",
+                "description": "Update operation of resource: committed-burst-size",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "committed-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "committed-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete committed-burst-size by ID",
+                "description": "Delete operation of resource: committed-burst-size",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/peak-information-rate/": {
+            "post": {
+                "summary": "Create peak-information-rate by ID",
+                "description": "Create operation of resource: peak-information-rate",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
@@ -11909,9 +12875,111 @@
                         "description": "Internal Error"
                     }
                 }
+            },
+            "put": {
+                "summary": "Update peak-information-rate by ID",
+                "description": "Update operation of resource: peak-information-rate",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-information-rate",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-information-ratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-information-rate by ID",
+                "description": "Delete operation of resource: peak-information-rate",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
             }
         },
         "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/peak-burst-size/": {
+            "post": {
+                "summary": "Create peak-burst-size by ID",
+                "description": "Create operation of resource: peak-burst-size",
+                "operationId": "create_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
@@ -11937,6 +13005,71 @@
                         "schema": {
                             "$ref": "#/definitions/capacity-value"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update peak-burst-size by ID",
+                "description": "Update operation of resource: peak-burst-size",
+                "operationId": "update_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "peak-burst-size",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        },
+                        "description": "peak-burst-sizebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete peak-burst-size by ID",
+                "description": "Delete operation of resource: peak-burst-size",
+                "operationId": "delete_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -12117,6 +13250,50 @@
             }
         },
         "/config/context/connectivity-service/{uuid}/cost-characteristic/{cost_name}/": {
+            "post": {
+                "summary": "Create cost-characteristic by ID",
+                "description": "Create operation of resource: cost-characteristic",
+                "operationId": "create_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost_name",
+                        "description": "ID of cost_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "cost-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        },
+                        "description": "cost-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
@@ -12149,6 +13326,85 @@
                         "schema": {
                             "$ref": "#/definitions/cost-characteristic"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update cost-characteristic by ID",
+                "description": "Update operation of resource: cost-characteristic",
+                "operationId": "update_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost_name",
+                        "description": "ID of cost_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "cost-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        },
+                        "description": "cost-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete cost-characteristic by ID",
+                "description": "Delete operation of resource: cost-characteristic",
+                "operationId": "delete_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost_name",
+                        "description": "ID of cost_name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -12194,6 +13450,50 @@
             }
         },
         "/config/context/connectivity-service/{uuid}/latency-characteristic/{traffic_property_name}/": {
+            "post": {
+                "summary": "Create latency-characteristic by ID",
+                "description": "Create operation of resource: latency-characteristic",
+                "operationId": "create_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic_property_name",
+                        "description": "ID of traffic_property_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "latency-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        },
+                        "description": "latency-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
             "get": {
                 "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
@@ -12226,6 +13526,85 @@
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update latency-characteristic by ID",
+                "description": "Update operation of resource: latency-characteristic",
+                "operationId": "update_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic_property_name",
+                        "description": "ID of traffic_property_name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "latency-characteristic",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        },
+                        "description": "latency-characteristicbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete latency-characteristic by ID",
+                "description": "Delete operation of resource: latency-characteristic",
+                "operationId": "delete_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic_property_name",
+                        "description": "ID of traffic_property_name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -15207,7 +16586,7 @@
                             "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
                         },
                         "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
+                            "$ref": "#/definitions/capacity"
                         },
                         "direction": {
                             "type": "string",

--- a/SWAGGER/tapi-otsi.swagger
+++ b/SWAGGER/tapi-otsi.swagger
@@ -15265,7 +15265,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
@@ -15672,7 +15673,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         },
@@ -15750,7 +15752,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -15790,7 +15793,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -15832,7 +15836,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "aggregated-node-edge-point": {
@@ -16366,7 +16371,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         }
                     }
@@ -16395,7 +16401,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "connectivity-service-end-point": {
@@ -16552,7 +16559,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         }
                     }
@@ -16578,7 +16586,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "service-interface-point": {
@@ -16809,7 +16818,8 @@
                         "OTU",
                         "ODU",
                         "ETH",
-                        "ETY"
+                        "ETY",
+                        "DSR"
                     ],
                     "description": "Indicate which layer this resilience parameters package configured for."
                 }
@@ -16885,7 +16895,8 @@
                             "OTU",
                             "ODU",
                             "ETH",
-                            "ETY"
+                            "ETY",
+                            "DSR"
                         ],
                         "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                     }

--- a/SWAGGER/tapi-path-computation.swagger
+++ b/SWAGGER/tapi-path-computation.swagger
@@ -10512,7 +10512,7 @@
                 }
             }
         },
-        "context": {
+        "tapi-context": {
             "allOf": [
                 {
                     "$ref": "#/definitions/global-class"
@@ -10701,7 +10701,7 @@
         "context_schema": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/context"
+                    "$ref": "#/definitions/tapi-context"
                 },
                 {
                     "properties": {

--- a/SWAGGER/tapi-path-computation.swagger
+++ b/SWAGGER/tapi-path-computation.swagger
@@ -1531,6 +1531,668 @@
                 }
             }
         },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
         "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/": {
             "get": {
                 "summary": "Retrieve node-rule-group",
@@ -10057,6 +10719,9 @@
                 },
                 {
                     "$ref": "#/definitions/termination-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
                 },
                 {
                     "properties": {

--- a/SWAGGER/tapi-path-computation.swagger
+++ b/SWAGGER/tapi-path-computation.swagger
@@ -9656,7 +9656,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         }
                     }
@@ -9804,7 +9805,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         },
@@ -9908,7 +9910,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         },
@@ -9981,7 +9984,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -10021,7 +10025,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -10063,7 +10068,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "aggregated-node-edge-point": {
@@ -10560,7 +10566,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }

--- a/SWAGGER/tapi-topology.swagger
+++ b/SWAGGER/tapi-topology.swagger
@@ -1531,6 +1531,668 @@
                 }
             }
         },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
         "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/": {
             "get": {
                 "summary": "Retrieve node-rule-group",
@@ -7028,6 +7690,9 @@
                 },
                 {
                     "$ref": "#/definitions/termination-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
                 },
                 {
                     "properties": {

--- a/SWAGGER/tapi-topology.swagger
+++ b/SWAGGER/tapi-topology.swagger
@@ -7513,7 +7513,7 @@
                 }
             }
         },
-        "context": {
+        "tapi-context": {
             "allOf": [
                 {
                     "$ref": "#/definitions/global-class"
@@ -7702,7 +7702,7 @@
         "context_schema": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/context"
+                    "$ref": "#/definitions/tapi-context"
                 },
                 {
                     "properties": {

--- a/SWAGGER/tapi-topology.swagger
+++ b/SWAGGER/tapi-topology.swagger
@@ -6876,7 +6876,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         },
@@ -6954,7 +6955,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -6994,7 +6996,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -7036,7 +7039,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "aggregated-node-edge-point": {
@@ -7561,7 +7565,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }

--- a/SWAGGER/tapi-virtual-network.swagger
+++ b/SWAGGER/tapi-virtual-network.swagger
@@ -9815,7 +9815,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         },
@@ -9880,7 +9881,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -9929,7 +9931,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         }
                     }
@@ -9996,7 +9999,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         },
@@ -10069,7 +10073,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -10109,7 +10114,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ]
                             }
                         }
@@ -10151,7 +10157,8 @@
                                 "OTU",
                                 "ODU",
                                 "ETH",
-                                "ETY"
+                                "ETY",
+                                "DSR"
                             ]
                         },
                         "aggregated-node-edge-point": {
@@ -10648,7 +10655,8 @@
                                     "OTU",
                                     "ODU",
                                     "ETH",
-                                    "ETY"
+                                    "ETY",
+                                    "DSR"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }

--- a/SWAGGER/tapi-virtual-network.swagger
+++ b/SWAGGER/tapi-virtual-network.swagger
@@ -1531,6 +1531,668 @@
                 }
             }
         },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned_node_edge_point_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned_node_edge_point_uuid",
+                        "description": "ID of owned_node_edge_point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
         "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/": {
             "get": {
                 "summary": "Retrieve node-rule-group",
@@ -10146,6 +10808,9 @@
                 },
                 {
                     "$ref": "#/definitions/termination-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
                 },
                 {
                     "properties": {

--- a/SWAGGER/tapi-virtual-network.swagger
+++ b/SWAGGER/tapi-virtual-network.swagger
@@ -10600,7 +10600,7 @@
                 }
             }
         },
-        "context": {
+        "tapi-context": {
             "allOf": [
                 {
                     "$ref": "#/definitions/global-class"
@@ -10789,7 +10789,7 @@
         "context_schema": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/context"
+                    "$ref": "#/definitions/tapi-context"
                 },
                 {
                     "properties": {

--- a/UML/TapiCommon.notation
+++ b/UML/TapiCommon.notation
@@ -363,13 +363,17 @@
           <element xmi:type="uml:EnumerationLiteral" href="TapiCommon.uml#_5nFycI5NEeeXQ5UBIdOSXw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_T9gHk-yrEee2fqmozVFruQ"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_sTtEkBNGEeiLUJsbV8C3vQ" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiCommon.uml#_p3xNoBNGEeiLUJsbV8C3vQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_sTtEkRNGEeiLUJsbV8C3vQ"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_9t0AwTA_Eea4fKwSGMr6CA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_9t0AwjA_Eea4fKwSGMr6CA"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_9t0AwzA_Eea4fKwSGMr6CA"/>
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9t0AxDA_Eea4fKwSGMr6CA"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9t0A1zA_Eea4fKwSGMr6CA" x="19" y="166" width="157" height="146"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9t0A1zA_Eea4fKwSGMr6CA" x="19" y="152" width="157" height="160"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BUkpIDK8EeaULOmJRJKM0Q" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_BUkpITK8EeaULOmJRJKM0Q" showTitle="true"/>
@@ -1535,6 +1539,14 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3rHvMhKKEeix4OZk6OGmSg" x="214" y="-116"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_nKGt6hNGEeiLUJsbV8C3vQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nKGt6xNGEeiLUJsbV8C3vQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nKGt7RNGEeiLUJsbV8C3vQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nKGt7BNGEeiLUJsbV8C3vQ" x="214" y="-116"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_iE1WsT3fEea-1_BGg-qcjQ" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_iE1Wsj3fEea-1_BGg-qcjQ"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_iE1Wsz3fEea-1_BGg-qcjQ">
@@ -2262,6 +2274,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3rHvNhKKEeix4OZk6OGmSg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3rHvNxKKEeix4OZk6OGmSg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3rHvOBKKEeix4OZk6OGmSg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nKGt7hNGEeiLUJsbV8C3vQ" type="StereotypeCommentLink" source="_O3-EAMhqEeaVlemTikmRHw" target="_nKGt6hNGEeiLUJsbV8C3vQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nKGt7xNGEeiLUJsbV8C3vQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nKGt8xNGEeiLUJsbV8C3vQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nKGt8BNGEeiLUJsbV8C3vQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nKGt8RNGEeiLUJsbV8C3vQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nKGt8hNGEeiLUJsbV8C3vQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_-RwAgE0WEeaqn4OIuRCwEg" type="PapyrusUMLClassDiagram" name="EndPointDetails" measurementUnit="Pixel">

--- a/UML/TapiCommon.notation
+++ b/UML/TapiCommon.notation
@@ -1527,6 +1527,14 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_N0BL4hJ-Eeix4OZk6OGmSg" x="214" y="-116"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_3rHvMBKKEeix4OZk6OGmSg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_3rHvMRKKEeix4OZk6OGmSg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3rHvMxKKEeix4OZk6OGmSg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3rHvMhKKEeix4OZk6OGmSg" x="214" y="-116"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_iE1WsT3fEea-1_BGg-qcjQ" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_iE1Wsj3fEea-1_BGg-qcjQ"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_iE1Wsz3fEea-1_BGg-qcjQ">
@@ -2244,6 +2252,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_N0BL5hJ-Eeix4OZk6OGmSg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_N0BL5xJ-Eeix4OZk6OGmSg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_N0BL6BJ-Eeix4OZk6OGmSg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_3rHvNBKKEeix4OZk6OGmSg" type="StereotypeCommentLink" source="_O3-EAMhqEeaVlemTikmRHw" target="_3rHvMBKKEeix4OZk6OGmSg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_3rHvNRKKEeix4OZk6OGmSg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3rHvORKKEeix4OZk6OGmSg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3rHvNhKKEeix4OZk6OGmSg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3rHvNxKKEeix4OZk6OGmSg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3rHvOBKKEeix4OZk6OGmSg"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_-RwAgE0WEeaqn4OIuRCwEg" type="PapyrusUMLClassDiagram" name="EndPointDetails" measurementUnit="Pixel">

--- a/UML/TapiCommon.uml
+++ b/UML/TapiCommon.uml
@@ -89,7 +89,7 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
         <ownedAttribute xmi:type="uml:Property" xmi:id="_TlA2g979EeW-BtRsuJPbqg" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ" isReadOnly="true"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_TlA2hN79EeW-BtRsuJPbqg" name="lifecycleState" type="_2wdyENnjEeWIOYiRCk5bbQ" isReadOnly="true"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_sfccMOK0EeSq5fATALSQkQ" name="Context" isLeaf="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_sfccMOK0EeSq5fATALSQkQ" name="TapiContext" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_sfccMeK0EeSq5fATALSQkQ">
           <body>The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements).</body>
         </ownedComment>

--- a/UML/TapiCommon.uml
+++ b/UML/TapiCommon.uml
@@ -278,6 +278,11 @@ Layer protocol names include:&#xD;
             <body>Models the ETY layer as per ITU-T G.8010</body>
           </ownedComment>
         </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_p3xNoBNGEeiLUJsbV8C3vQ" name="DSR">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_FbqAcBNHEeiLUJsbV8C3vQ" annotatedElement="_p3xNoBNGEeiLUJsbV8C3vQ">
+            <body>Models a Digital Signal of an unspecified rate. This value can be used when the intent is to respresent an generic digital layer signal without making any statement on its format or overhead (processing) capabilities.</body>
+          </ownedComment>
+        </ownedLiteral>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_2wdyENnjEeWIOYiRCk5bbQ" name="LifecycleState" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_2wdyEdnjEeWIOYiRCk5bbQ" annotatedElement="_2wdyENnjEeWIOYiRCk5bbQ">

--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -3882,14 +3882,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Wn2ipUwFEeewALXL7BvPYw" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_uUeTgEwGEeewALXL7BvPYw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_uUeTgUwGEeewALXL7BvPYw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uUeTg0wGEeewALXL7BvPYw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_nJo58EwFEeewALXL7BvPYw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uUeTgkwGEeewALXL7BvPYw" x="215" y="221"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_n4MtoMZaEeeAD9H5zOiMUQ" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_n4NUscZaEeeAD9H5zOiMUQ" type="5029"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_n4NUssZaEeeAD9H5zOiMUQ" type="8510">
@@ -4023,41 +4015,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Wn3JskwFEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Wn3Js0wFEeewALXL7BvPYw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Wn3JtEwFEeewALXL7BvPYw"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_nLYmYEwFEeewALXL7BvPYw" type="4001" source="_rT034EwEEeewALXL7BvPYw" target="_Wnt_wEwFEeewALXL7BvPYw">
-      <children xmi:type="notation:DecorationNode" xmi:id="_nLYmY0wFEeewALXL7BvPYw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_nLYmZEwFEeewALXL7BvPYw" x="-4" y="10"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_nLYmZUwFEeewALXL7BvPYw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_nLYmZkwFEeewALXL7BvPYw" x="-2" y="-12"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_nLYmZ0wFEeewALXL7BvPYw" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_nLYmaEwFEeewALXL7BvPYw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_nLYmaUwFEeewALXL7BvPYw" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_nLYmakwFEeewALXL7BvPYw" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_nLYma0wFEeewALXL7BvPYw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_nLYmbEwFEeewALXL7BvPYw" x="15" y="19"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_nLYmbUwFEeewALXL7BvPYw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_nLYmbkwFEeewALXL7BvPYw" x="-17" y="16"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_nLYmYUwFEeewALXL7BvPYw"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_nJo58EwFEeewALXL7BvPYw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nLYmYkwFEeewALXL7BvPYw" points="[15, 0, -301, -9]$[306, 6, -10, -3]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nMlgQEwFEeewALXL7BvPYw" id="(1.0,0.4387755102040816)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nMlgQUwFEeewALXL7BvPYw" id="(0.0,0.5053763440860215)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_uUeThEwGEeewALXL7BvPYw" type="StereotypeCommentLink" source="_nLYmYEwFEeewALXL7BvPYw" target="_uUeTgEwGEeewALXL7BvPYw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_uUeThUwGEeewALXL7BvPYw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uUeTiUwGEeewALXL7BvPYw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_nJo58EwFEeewALXL7BvPYw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uUeThkwGEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uUeTh0wGEeewALXL7BvPYw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uUeTiEwGEeewALXL7BvPYw"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_n4UpccZaEeeAD9H5zOiMUQ" type="StereotypeCommentLink" source="_n4MtoMZaEeeAD9H5zOiMUQ" target="_n4UCY8ZaEeeAD9H5zOiMUQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_n4UpcsZaEeeAD9H5zOiMUQ"/>

--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -4246,13 +4246,13 @@
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_CpfldOsbEealN7CdLT_GPw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_-tUJxfIrEea79czpMf3AVQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_v8PHIIhBEeeOl5P_FBJSmA" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_v8PHIYhBEeeOl5P_FBJSmA"/>
+        <children xmi:type="notation:Shape" xmi:id="_a1CowBNbEeiKtYjI8wVF7A" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_a1CowRNbEeiKtYjI8wVF7A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_v8PuMIhBEeeOl5P_FBJSmA" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_v8PuMYhBEeeOl5P_FBJSmA"/>
+        <children xmi:type="notation:Shape" xmi:id="_a1DP0BNbEeiKtYjI8wVF7A" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_a1DP0RNbEeiKtYjI8wVF7A"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_s9Rl5ur0EeaeHOJw3lCT8A"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_s9Rl5-r0EeaeHOJw3lCT8A"/>

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -460,8 +460,8 @@ The structure of LTP supports all transport protocols including circuit and pack
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_DOEi4O-IEeWLlrwIF3w0vA" name="ConnectivityConstraint">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_lY2XULvZEeWYrqoqXLgguw" name="serviceType" type="_0-X6sLvZEeWYrqoqXLgguw" isReadOnly="true"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_3bhE4L2BEeWdore3Cxez9g" name="serviceLevel" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_lY2XULvZEeWYrqoqXLgguw" name="serviceType" type="_0-X6sLvZEeWYrqoqXLgguw"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3bhE4L2BEeWdore3Cxez9g" name="serviceLevel">
           <ownedComment xmi:type="uml:Comment" xmi:id="_8GC6UL2BEeWdore3Cxez9g">
             <body>An abstract value the meaning of which is mutually agreed – typically represents metrics such as - Class of service, priority, resiliency, availability</body>
           </ownedComment>
@@ -476,7 +476,7 @@ The structure of LTP supports all transport protocols including circuit and pack
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
           <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_-iMboIfYEeeirpBaj87qAw" value="true"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_-YtW8L11EeWdore3Cxez9g" name="requestedCapacity" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_-YtW8L11EeWdore3Cxez9g" name="requestedCapacity">
           <type xmi:type="uml:DataType" href="TapiCommon.uml#_rNbewL1-EeWdore3Cxez9g"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_ru76gGNFEee0bPnI-Gt-mQ" name="schedule">
@@ -484,7 +484,7 @@ The structure of LTP supports all transport protocols including circuit and pack
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_MrlDoIhGEeeOl5P_FBJSmA"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Mrm40IhGEeeOl5P_FBJSmA" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_RhdgwL2HEeWdore3Cxez9g" name="costCharacteristic" visibility="public" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_RhdgwL2HEeWdore3Cxez9g" name="costCharacteristic" visibility="public">
           <ownedComment xmi:type="uml:Comment" xmi:id="_Rhdgwb2HEeWdore3Cxez9g" annotatedElement="_RhdgwL2HEeWdore3Cxez9g">
             <body>The list of costs where each cost relates to some aspect of the TopologicalEntity.</body>
           </ownedComment>
@@ -492,7 +492,7 @@ The structure of LTP supports all transport protocols including circuit and pack
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Rhdgwr2HEeWdore3Cxez9g"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Rhdgw72HEeWdore3Cxez9g" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_GqeeML2JEeWdore3Cxez9g" name="latencyCharacteristic" visibility="public" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_GqeeML2JEeWdore3Cxez9g" name="latencyCharacteristic" visibility="public">
           <ownedComment xmi:type="uml:Comment" xmi:id="_GqeeMb2JEeWdore3Cxez9g" annotatedElement="_GqeeML2JEeWdore3Cxez9g">
             <body>The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.</body>
           </ownedComment>
@@ -504,11 +504,11 @@ The structure of LTP supports all transport protocols including circuit and pack
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_BTPtUIfhEeet-8tHdGGp_w"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_BTRigIfhEeet-8tHdGGp_w" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_l8TgscF3EeaALJQAf08uAg" name="_corouteInclusion" type="_kuDzQEHaEeWqPKyD1j6LMg" isReadOnly="true" association="_l8BM0MF3EeaALJQAf08uAg">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_l8TgscF3EeaALJQAf08uAg" name="_corouteInclusion" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_l8BM0MF3EeaALJQAf08uAg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_zv3oIMGAEeaALJQAf08uAg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_zxHlUcGAEeaALJQAf08uAg" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_wt-RckXOEeaB8vMnkFQLXQ" name="_diversityExclusion" type="_kuDzQEHaEeWqPKyD1j6LMg" isReadOnly="true" association="_wt9DUEXOEeaB8vMnkFQLXQ">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_wt-RckXOEeaB8vMnkFQLXQ" name="_diversityExclusion" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_wt9DUEXOEeaB8vMnkFQLXQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Oi89IEXPEeaB8vMnkFQLXQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OjBOkEXPEeaB8vMnkFQLXQ" value="*"/>
         </ownedAttribute>
@@ -573,8 +573,8 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
         <ownedAttribute xmi:type="uml:Property" xmi:id="_EN4L8WJREeek3OrhDuslYQ" name="_state" aggregation="composite" association="_EN290GJREeek3OrhDuslYQ">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_nJqIEUwFEeewALXL7BvPYw" name="_capacity" aggregation="composite" association="_nJo58EwFEeewALXL7BvPYw">
-          <type xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nJqIEUwFEeewALXL7BvPYw" name="capacity" aggregation="composite" association="_nJo58EwFEeewALXL7BvPYw">
+          <type xmi:type="uml:DataType" href="TapiCommon.uml#_rNbewL1-EeWdore3Cxez9g"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_MIWTK2h5EeWZEqTYAF8eqA" name="direction" visibility="public">
           <ownedComment xmi:type="uml:Comment" xmi:id="_MIWTLGh5EeWZEqTYAF8eqA" annotatedElement="_MIWTK2h5EeWZEqTYAF8eqA">

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -672,8 +672,8 @@ This ability allows multiple alternate routes to be present that otherwise would
         <ownedComment xmi:type="uml:Comment" xmi:id="_nuZ_MeryEeaeHOJw3lCT8A" annotatedElement="_nuZ_MOryEeaeHOJw3lCT8A">
           <body>Represents the capability to control and coordinate switches, to add/delete/modify FCs and to add/delete/modify LTPs/LPs so as to realize a protection scheme.</body>
         </ownedComment>
-        <generalization xmi:type="uml:Generalization" xmi:id="_A4JfEPIrEea79czpMf3AVQ">
-          <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+        <generalization xmi:type="uml:Generalization" xmi:id="_ZOeTkBNbEeiKtYjI8wVF7A">
+          <general xmi:type="uml:Class" href="TapiCommon.uml#_tjWBYD3fEea-1_BGg-qcjQ"/>
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_wpkK0O38EeaRONVEJOGI1g" name="_subSwitchControl" type="_nuZ_MOryEeaeHOJw3lCT8A" association="_wpXWgO38EeaRONVEJOGI1g">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_FLsLEO39EeaRONVEJOGI1g"/>

--- a/UML/TapiEth.notation
+++ b/UML/TapiEth.notation
@@ -428,38 +428,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5_E_IjlGEeaHY8ihI-WgZg" x="1645" y="565"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_W13np0WlEeaB8vMnkFQLXQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_W13nqEWlEeaB8vMnkFQLXQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_W13nqkWlEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_ITi4QDN-Eea40e5DA9KE3w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W13nqUWlEeaB8vMnkFQLXQ" x="271" y="89"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_W13nwEWlEeaB8vMnkFQLXQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_W13nwUWlEeaB8vMnkFQLXQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_W13nw0WlEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_3Dz-kDO5Eea40e5DA9KE3w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W13nwkWlEeaB8vMnkFQLXQ" x="714" y="270"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_W13n2UWlEeaB8vMnkFQLXQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_W13n2kWlEeaB8vMnkFQLXQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_W13n3EWlEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_AbxMcDO6Eea40e5DA9KE3w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W13n20WlEeaB8vMnkFQLXQ" x="714" y="270"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_W13n8kWlEeaB8vMnkFQLXQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_W13n80WlEeaB8vMnkFQLXQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_W13n9UWlEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#__17LsDN9Eea40e5DA9KE3w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W13n9EWlEeaB8vMnkFQLXQ" x="271" y="89"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_saAXO0WoEeaB8vMnkFQLXQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_saAXPEWoEeaB8vMnkFQLXQ" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_saAXPkWoEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
@@ -598,14 +566,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Cpa4RUWsEeaB8vMnkFQLXQ" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_I0TtM0WsEeaB8vMnkFQLXQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_I0TtNEWsEeaB8vMnkFQLXQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_I0c3IEWsEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_IyE4kEWsEeaB8vMnkFQLXQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_I0TtNUWsEeaB8vMnkFQLXQ" x="127" y="32"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_l31pIMivEees0-2jg5eWTg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_l31pIcivEees0-2jg5eWTg" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_l31pI8ivEees0-2jg5eWTg" name="BASE_ELEMENT">
@@ -621,6 +581,46 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nAesMsivEees0-2jg5eWTg" x="220" y="-82"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_TgMc8xNtEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_TgMc9BNtEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TgMc9hNtEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#__17LsDN9Eea40e5DA9KE3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TgMc9RNtEeiod932A6hg3A" x="527" y="-88"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_U-Q9cxNtEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_U-Q9dBNtEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_U-Q9dhNtEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_ITi4QDN-Eea40e5DA9KE3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_U-Q9dRNtEeiod932A6hg3A" x="527" y="-88"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_WcoY4xNtEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WcoY5BNtEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WcoY5hNtEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_IyE4kEWsEeaB8vMnkFQLXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WcoY5RNtEeiod932A6hg3A" x="220" y="-82"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dMp7MxNtEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dMp7NBNtEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dMp7NhNtEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_AbxMcDO6Eea40e5DA9KE3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dMp7NRNtEeiod932A6hg3A" x="860" y="186"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_eg_38xNtEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eg_39BNtEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eg_39hNtEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_3Dz-kDO5Eea40e5DA9KE3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eg_39RNtEeiod932A6hg3A" x="860" y="186"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_Oq90sTN7Eea40e5DA9KE3w" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_Oq90sjN7Eea40e5DA9KE3w"/>
@@ -830,46 +830,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5KoBzlGEeaHY8ihI-WgZg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F5KoCDlGEeaHY8ihI-WgZg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_W13nq0WlEeaB8vMnkFQLXQ" type="StereotypeCommentLink" source="_IUR4EDN-Eea40e5DA9KE3w" target="_W13np0WlEeaB8vMnkFQLXQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_W13nrEWlEeaB8vMnkFQLXQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_W13nsEWlEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_ITi4QDN-Eea40e5DA9KE3w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_W13nrUWlEeaB8vMnkFQLXQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W13nrkWlEeaB8vMnkFQLXQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W13nr0WlEeaB8vMnkFQLXQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_W13nxEWlEeaB8vMnkFQLXQ" type="StereotypeCommentLink" source="_3FtcADO5Eea40e5DA9KE3w" target="_W13nwEWlEeaB8vMnkFQLXQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_W13nxUWlEeaB8vMnkFQLXQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_W13nyUWlEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_3Dz-kDO5Eea40e5DA9KE3w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_W13nxkWlEeaB8vMnkFQLXQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W13nx0WlEeaB8vMnkFQLXQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W13nyEWlEeaB8vMnkFQLXQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_W13n3UWlEeaB8vMnkFQLXQ" type="StereotypeCommentLink" source="_Adj8MDO6Eea40e5DA9KE3w" target="_W13n2UWlEeaB8vMnkFQLXQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_W13n3kWlEeaB8vMnkFQLXQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_W13n4kWlEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_AbxMcDO6Eea40e5DA9KE3w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_W13n30WlEeaB8vMnkFQLXQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W13n4EWlEeaB8vMnkFQLXQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W13n4UWlEeaB8vMnkFQLXQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_W13n9kWlEeaB8vMnkFQLXQ" type="StereotypeCommentLink" source="__2PUwDN9Eea40e5DA9KE3w" target="_W13n8kWlEeaB8vMnkFQLXQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_W13n90WlEeaB8vMnkFQLXQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_W13n-0WlEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#__17LsDN9Eea40e5DA9KE3w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_W13n-EWlEeaB8vMnkFQLXQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W13n-UWlEeaB8vMnkFQLXQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W13n-kWlEeaB8vMnkFQLXQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_xJRiqkWoEeaB8vMnkFQLXQ" type="StereotypeCommentLink" target="_xJRipkWoEeaB8vMnkFQLXQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_xJRiq0WoEeaB8vMnkFQLXQ"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xJRir0WoEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
@@ -935,16 +895,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_I2F14EWsEeaB8vMnkFQLXQ" id="(0.3724696356275304,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_I2F14UWsEeaB8vMnkFQLXQ" id="(0.50199203187251,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_I0c3IUWsEeaB8vMnkFQLXQ" type="StereotypeCommentLink" source="_Iy9pYEWsEeaB8vMnkFQLXQ" target="_I0TtM0WsEeaB8vMnkFQLXQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_I0c3IkWsEeaB8vMnkFQLXQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_I0c3JkWsEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_IyE4kEWsEeaB8vMnkFQLXQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_I0c3I0WsEeaB8vMnkFQLXQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_I0c3JEWsEeaB8vMnkFQLXQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_I0c3JUWsEeaB8vMnkFQLXQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ea6kkMivEees0-2jg5eWTg" type="4006" source="_Co1CYEWsEeaB8vMnkFQLXQ" target="_GimlwEWrEeaB8vMnkFQLXQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_ebBSQMivEees0-2jg5eWTg" type="6014">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_ebBSQcivEees0-2jg5eWTg" x="5" y="5"/>
@@ -990,6 +940,56 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nAesNsivEees0-2jg5eWTg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nAesN8ivEees0-2jg5eWTg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nAesOMivEees0-2jg5eWTg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_TgMc9xNtEeiod932A6hg3A" type="StereotypeCommentLink" source="__2PUwDN9Eea40e5DA9KE3w" target="_TgMc8xNtEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_TgMc-BNtEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TgMc_BNtEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#__17LsDN9Eea40e5DA9KE3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TgMc-RNtEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TgMc-hNtEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TgMc-xNtEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_U-Q9dxNtEeiod932A6hg3A" type="StereotypeCommentLink" source="_IUR4EDN-Eea40e5DA9KE3w" target="_U-Q9cxNtEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_U-Q9eBNtEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_U-Q9fBNtEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_ITi4QDN-Eea40e5DA9KE3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_U-Q9eRNtEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U-Q9ehNtEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U-Q9exNtEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WcoY5xNtEeiod932A6hg3A" type="StereotypeCommentLink" source="_Iy9pYEWsEeaB8vMnkFQLXQ" target="_WcoY4xNtEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WcoY6BNtEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WcoY7BNtEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_IyE4kEWsEeaB8vMnkFQLXQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WcoY6RNtEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WcoY6hNtEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WcoY6xNtEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dMp7NxNtEeiod932A6hg3A" type="StereotypeCommentLink" source="_Adj8MDO6Eea40e5DA9KE3w" target="_dMp7MxNtEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dMp7OBNtEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dMp7PBNtEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_AbxMcDO6Eea40e5DA9KE3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dMp7ORNtEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dMp7OhNtEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dMp7OxNtEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_eg_39xNtEeiod932A6hg3A" type="StereotypeCommentLink" source="_3FtcADO5Eea40e5DA9KE3w" target="_eg_38xNtEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_eg_3-BNtEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eg_3_BNtEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiEth.uml#_3Dz-kDO5Eea40e5DA9KE3w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eg_3-RNtEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eg_3-hNtEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eg_3-xNtEeiod932A6hg3A"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiEth.uml
+++ b/UML/TapiEth.uml
@@ -339,7 +339,7 @@ If none of the above addresses match, the ETH_CI_D is passed.&#xD;
         <ownedComment xmi:type="uml:Comment" xmi:id="_I4OBgFBDEeWBGOds9dR2yw" annotatedElement="_8QR1UK4wEeGjbtFXtCFKWg">
           <body>Basic attributes: codirectional, condConfigList, prioConfigList</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Tg7zoOhhEeG35t-G7oiZlg" name="prioConfigList1" visibility="public" type="_inWUgK5KEeGXRumldg-1oA" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Tg7zoOhhEeG35t-G7oiZlg" name="prioConfigList" visibility="public" type="_inWUgK5KEeGXRumldg-1oA" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_4ctfoOuSEeGZr5p9Vdkojw" annotatedElement="_Tg7zoOhhEeG35t-G7oiZlg">
             <body>This attribute indicates the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.</body>
           </ownedComment>
@@ -366,7 +366,7 @@ If none of the above addresses match, the ETH_CI_D is passed.&#xD;
             <name xsi:nil="true"/>
           </defaultValue>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_PHrv4LoIEeGh2ojTLz6Azw" name="codirectional1" visibility="public" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_PHrv4LoIEeGh2ojTLz6Azw" name="codirectional" visibility="public" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_XllKMOuVEeGZr5p9Vdkojw" annotatedElement="_PHrv4LoIEeGh2ojTLz6Azw">
             <body>This attribute indicates the direction of the conditioner. The value of true means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the sink part of the containing CTP. The value of false means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the source part of the containing CTP.</body>
           </ownedComment>
@@ -5029,9 +5029,9 @@ DEI = Drop Eligibility Indicator</body>
   <OpenModel_Profile_3:Specify xmi:id="_nAWJUMivEees0-2jg5eWTg" base_Abstraction="_earUAMivEees0-2jg5eWTg">
     <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_ownedNodeEdgePoint</target>
   </OpenModel_Profile_3:Specify>
-  <OpenModel_Profile_3:ExtendedComposite xmi:id="_lHKOIM4VEeehIvzuBRCtZQ" base_Association="_AbxMcDO6Eea40e5DA9KE3w"/>
-  <OpenModel_Profile_3:ExtendedComposite xmi:id="_q68xsM4VEeehIvzuBRCtZQ" base_Association="_3Dz-kDO5Eea40e5DA9KE3w"/>
-  <OpenModel_Profile_3:ExtendedComposite xmi:id="_vOuUAM4VEeehIvzuBRCtZQ" base_Association="__17LsDN9Eea40e5DA9KE3w"/>
-  <OpenModel_Profile_3:ExtendedComposite xmi:id="_w4S54M4VEeehIvzuBRCtZQ" base_Association="_ITi4QDN-Eea40e5DA9KE3w"/>
-  <OpenModel_Profile_3:ExtendedComposite xmi:id="_1cNJ8M4VEeehIvzuBRCtZQ" base_Association="_IyE4kEWsEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_3:StrictComposite xmi:id="_TgGWUBNtEeiod932A6hg3A" base_Association="__17LsDN9Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_3:StrictComposite xmi:id="_U-K20BNtEeiod932A6hg3A" base_Association="_ITi4QDN-Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_3:StrictComposite xmi:id="_WciSQBNtEeiod932A6hg3A" base_Association="_IyE4kEWsEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_3:StrictComposite xmi:id="_dMj0kBNtEeiod932A6hg3A" base_Association="_AbxMcDO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_3:StrictComposite xmi:id="_eg5xUBNtEeiod932A6hg3A" base_Association="_3Dz-kDO5Eea40e5DA9KE3w"/>
 </xmi:XMI>

--- a/UML/TapiNotification.notation
+++ b/UML/TapiNotification.notation
@@ -32,7 +32,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whCh8DBHEeam35bpdXJzEw"/>
     </children>
     <element xmi:type="uml:Enumeration" href="TapiNotification.uml#_hZotgCzcEeaYO8M_h7XJ5A"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whCiAzBHEeam35bpdXJzEw" x="993" y="523"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whCiAzBHEeam35bpdXJzEw" x="635" y="585"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_whCiBDBHEeam35bpdXJzEw" type="2006">
     <children xmi:type="notation:DecorationNode" xmi:id="_whCiBTBHEeam35bpdXJzEw" type="5023"/>
@@ -58,7 +58,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whCiEjBHEeam35bpdXJzEw"/>
     </children>
     <element xmi:type="uml:Enumeration" href="TapiNotification.uml#_bgwjsCzeEeaYO8M_h7XJ5A"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whCiJTBHEeam35bpdXJzEw" x="790" y="503" height="91"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whCiJTBHEeam35bpdXJzEw" x="868" y="595" height="91"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_whCiJjBHEeam35bpdXJzEw" type="2008">
     <children xmi:type="notation:DecorationNode" xmi:id="_whCiJzBHEeam35bpdXJzEw" type="5029"/>
@@ -226,7 +226,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMT7jBHEeam35bpdXJzEw"/>
     </children>
     <element xmi:type="uml:Enumeration" href="TapiNotification.uml#_Rjd84C0aEeah7qIgVNfKeA"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMUATBHEeam35bpdXJzEw" x="804" y="612" height="82"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMUATBHEeam35bpdXJzEw" x="650" y="739" height="82"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_whMUAjBHEeam35bpdXJzEw" type="2006">
     <children xmi:type="notation:DecorationNode" xmi:id="_whMUAzBHEeam35bpdXJzEw" type="5023"/>
@@ -234,49 +234,89 @@
       <layoutConstraint xmi:type="notation:Location" xmi:id="_whMUBTBHEeam35bpdXJzEw" y="5"/>
     </children>
     <children xmi:type="notation:BasicCompartment" xmi:id="_whMUBjBHEeam35bpdXJzEw" type="7015">
-      <children xmi:type="notation:Shape" xmi:id="_whMUBzBHEeam35bpdXJzEw" type="3017">
+      <children xmi:type="notation:Shape" xmi:id="_e2YzwBNaEeiKtYjI8wVF7A" type="3017">
         <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_Jsw9oCzeEeaYO8M_h7XJ5A"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_whMUCDBHEeam35bpdXJzEw"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2YzwRNaEeiKtYjI8wVF7A"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_whMUCTBHEeam35bpdXJzEw" type="3017">
+      <children xmi:type="notation:Shape" xmi:id="_e2Za0BNaEeiKtYjI8wVF7A" type="3017">
         <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_KpUFcCzeEeaYO8M_h7XJ5A"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_whMUCjBHEeam35bpdXJzEw"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2Za0RNaEeiKtYjI8wVF7A"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_whMUCzBHEeam35bpdXJzEw" type="3017">
+      <children xmi:type="notation:Shape" xmi:id="_e2aB4BNaEeiKtYjI8wVF7A" type="3017">
         <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_LaJFcCzeEeaYO8M_h7XJ5A"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_whMUDDBHEeam35bpdXJzEw"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2aB4RNaEeiKtYjI8wVF7A"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_whMUDTBHEeam35bpdXJzEw" type="3017">
+      <children xmi:type="notation:Shape" xmi:id="_e2aB4hNaEeiKtYjI8wVF7A" type="3017">
         <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_MakAoCzeEeaYO8M_h7XJ5A"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_whMUDjBHEeam35bpdXJzEw"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2aB4xNaEeiKtYjI8wVF7A"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_whMUDzBHEeam35bpdXJzEw" type="3017">
+      <children xmi:type="notation:Shape" xmi:id="_e2aB5BNaEeiKtYjI8wVF7A" type="3017">
         <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_NRwuYCzeEeaYO8M_h7XJ5A"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_whMUEDBHEeam35bpdXJzEw"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2aB5RNaEeiKtYjI8wVF7A"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_whMUETBHEeam35bpdXJzEw" type="3017">
+      <children xmi:type="notation:Shape" xmi:id="_e2aB5hNaEeiKtYjI8wVF7A" type="3017">
         <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_OxHoUCzeEeaYO8M_h7XJ5A"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_whMUEjBHEeam35bpdXJzEw"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2aB5xNaEeiKtYjI8wVF7A"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_whMUEzBHEeam35bpdXJzEw" type="3017">
+      <children xmi:type="notation:Shape" xmi:id="_e2aB6BNaEeiKtYjI8wVF7A" type="3017">
         <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_RB-QoCzeEeaYO8M_h7XJ5A"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_whMUFDBHEeam35bpdXJzEw"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2aB6RNaEeiKtYjI8wVF7A"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_whMUFTBHEeam35bpdXJzEw" type="3017">
+      <children xmi:type="notation:Shape" xmi:id="_e2ao8BNaEeiKtYjI8wVF7A" type="3017">
         <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_SlD0ACzeEeaYO8M_h7XJ5A"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_whMUFjBHEeam35bpdXJzEw"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2ao8RNaEeiKtYjI8wVF7A"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_whMUFzBHEeam35bpdXJzEw" type="3017">
+      <children xmi:type="notation:Shape" xmi:id="_e2ao8hNaEeiKtYjI8wVF7A" type="3017">
         <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_UVnLoCzeEeaYO8M_h7XJ5A"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_whMUGDBHEeam35bpdXJzEw"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2ao8xNaEeiKtYjI8wVF7A"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_whMUGTBHEeam35bpdXJzEw" type="3017">
+      <children xmi:type="notation:Shape" xmi:id="_e2ao9BNaEeiKtYjI8wVF7A" type="3017">
         <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_Vq3uYCzeEeaYO8M_h7XJ5A"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_whMUGjBHEeam35bpdXJzEw"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2ao9RNaEeiKtYjI8wVF7A"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_whMUGzBHEeam35bpdXJzEw" type="3017">
+      <children xmi:type="notation:Shape" xmi:id="_e2ao9hNaEeiKtYjI8wVF7A" type="3017">
         <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_XRFeQCzeEeaYO8M_h7XJ5A"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_whMUHDBHEeam35bpdXJzEw"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2ao9xNaEeiKtYjI8wVF7A"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_e2ao-BNaEeiKtYjI8wVF7A" type="3017">
+        <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#__WB2QBNXEeiKtYjI8wVF7A"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2ao-RNaEeiKtYjI8wVF7A"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_e2bQABNaEeiKtYjI8wVF7A" type="3017">
+        <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_CILNwBNYEeiKtYjI8wVF7A"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2bQARNaEeiKtYjI8wVF7A"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_e2bQAhNaEeiKtYjI8wVF7A" type="3017">
+        <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_EpIHkBNYEeiKtYjI8wVF7A"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2bQAxNaEeiKtYjI8wVF7A"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_e2bQBBNaEeiKtYjI8wVF7A" type="3017">
+        <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_GI_-4BNYEeiKtYjI8wVF7A"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2bQBRNaEeiKtYjI8wVF7A"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_e2bQBhNaEeiKtYjI8wVF7A" type="3017">
+        <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_vV3I0BNYEeiKtYjI8wVF7A"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2bQBxNaEeiKtYjI8wVF7A"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_e2bQCBNaEeiKtYjI8wVF7A" type="3017">
+        <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_wPccMBNYEeiKtYjI8wVF7A"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2b3EBNaEeiKtYjI8wVF7A"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_e2b3ERNaEeiKtYjI8wVF7A" type="3017">
+        <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_xSSZQBNYEeiKtYjI8wVF7A"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2b3EhNaEeiKtYjI8wVF7A"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_e2ceIBNaEeiKtYjI8wVF7A" type="3017">
+        <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_MKoKIBNYEeiKtYjI8wVF7A"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2ceIRNaEeiKtYjI8wVF7A"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_e2ceIhNaEeiKtYjI8wVF7A" type="3017">
+        <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_Na--wBNYEeiKtYjI8wVF7A"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2ceIxNaEeiKtYjI8wVF7A"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_e2ceJBNaEeiKtYjI8wVF7A" type="3017">
+        <element xmi:type="uml:EnumerationLiteral" href="TapiNotification.uml#_tPnOABNYEeiKtYjI8wVF7A"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e2ceJRNaEeiKtYjI8wVF7A"/>
       </children>
       <styles xmi:type="notation:TitleStyle" xmi:id="_whMUHTBHEeam35bpdXJzEw"/>
       <styles xmi:type="notation:SortingStyle" xmi:id="_whMUHjBHEeam35bpdXJzEw"/>
@@ -284,7 +324,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMUIDBHEeam35bpdXJzEw"/>
     </children>
     <element xmi:type="uml:Enumeration" href="TapiNotification.uml#_FFtS8CzeEeaYO8M_h7XJ5A"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMUMzBHEeam35bpdXJzEw" x="871" y="212"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMUMzBHEeam35bpdXJzEw" x="797" y="190"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_whMUSDBHEeam35bpdXJzEw" type="2003">
     <children xmi:type="notation:DecorationNode" xmi:id="_whMUSTBHEeam35bpdXJzEw" type="5008"/>
@@ -711,7 +751,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a_-dPtwqEeaaobmDldrjOQ"/>
     </children>
     <element xmi:type="uml:DataType" href="TapiNotification.uml#__Pe64CznEeaYO8M_h7XJ5A"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a_-dMdwqEeaaobmDldrjOQ" x="798" y="720" height="99"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a_-dMdwqEeaaobmDldrjOQ" x="799" y="727" height="99"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_bAEj3NwqEeaaobmDldrjOQ" type="StereotypeComment">
     <styles xmi:type="notation:TitleStyle" xmi:id="_bAEj3dwqEeaaobmDldrjOQ" showTitle="true"/>
@@ -765,7 +805,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5B30dNwzEeaaobmDldrjOQ"/>
     </children>
     <element xmi:type="uml:Enumeration" href="TapiNotification.uml#_5ByU4NwzEeaaobmDldrjOQ"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5B2mUdwzEeaaobmDldrjOQ" x="992" y="689"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5B2mUdwzEeaaobmDldrjOQ" x="993" y="696"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_5CF249wzEeaaobmDldrjOQ" type="StereotypeComment">
     <styles xmi:type="notation:TitleStyle" xmi:id="_5CF25NwzEeaaobmDldrjOQ" showTitle="true"/>
@@ -1084,6 +1124,22 @@
     </styles>
     <element xsi:nil="true"/>
     <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nPpcQhJ_Eeix4OZk6OGmSg" x="522" y="368"/>
+  </children>
+  <children xmi:type="notation:Shape" xmi:id="_ecplcBNXEeiKtYjI8wVF7A" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_ecplcRNXEeiKtYjI8wVF7A" showTitle="true"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ecqMgBNXEeiKtYjI8wVF7A" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_HA6K4CB_EeeWCKlkirNtnw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ecplchNXEeiKtYjI8wVF7A" x="522" y="368"/>
+  </children>
+  <children xmi:type="notation:Shape" xmi:id="_Xo0Z0BNaEeiKtYjI8wVF7A" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_Xo0Z0RNaEeiKtYjI8wVF7A" showTitle="true"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Xo0Z0xNaEeiKtYjI8wVF7A" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_HA6K4CB_EeeWCKlkirNtnw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Xo0Z0hNaEeiKtYjI8wVF7A" x="522" y="368"/>
   </children>
   <styles xmi:type="notation:StringValueStyle" xmi:id="_tIFpETBHEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.1.0"/>
   <styles xmi:type="notation:DiagramStyle" xmi:id="_tIFpEjBHEeam35bpdXJzEw"/>
@@ -1702,5 +1758,25 @@
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nPpcRhJ_Eeix4OZk6OGmSg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nPpcRxJ_Eeix4OZk6OGmSg"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nPpcSBJ_Eeix4OZk6OGmSg"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_ecqMgRNXEeiKtYjI8wVF7A" type="StereotypeCommentLink" source="_HBxtkCB_EeeWCKlkirNtnw" target="_ecplcBNXEeiKtYjI8wVF7A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_ecqMghNXEeiKtYjI8wVF7A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ecqMhhNXEeiKtYjI8wVF7A" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_HA6K4CB_EeeWCKlkirNtnw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ecqMgxNXEeiKtYjI8wVF7A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ecqMhBNXEeiKtYjI8wVF7A"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ecqMhRNXEeiKtYjI8wVF7A"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_Xo0Z1BNaEeiKtYjI8wVF7A" type="StereotypeCommentLink" source="_HBxtkCB_EeeWCKlkirNtnw" target="_Xo0Z0BNaEeiKtYjI8wVF7A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_Xo0Z1RNaEeiKtYjI8wVF7A"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Xo1A4hNaEeiKtYjI8wVF7A" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_HA6K4CB_EeeWCKlkirNtnw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Xo0Z1hNaEeiKtYjI8wVF7A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xo1A4BNaEeiKtYjI8wVF7A"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xo1A4RNaEeiKtYjI8wVF7A"/>
   </edges>
 </notation:Diagram>

--- a/UML/TapiNotification.uml
+++ b/UML/TapiNotification.uml
@@ -353,6 +353,16 @@ This specifics of this is typically dependent on the implementation protocol &am
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_UVnLoCzeEeaYO8M_h7XJ5A" name="NODE_EDGE_POINT"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Vq3uYCzeEeaYO8M_h7XJ5A" name="SERVICE_INTERFACE_POINT"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_XRFeQCzeEeaYO8M_h7XJ5A" name="CONNECTION_END_POINT"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__WB2QBNXEeiKtYjI8wVF7A" name="MAINTENANCE_ENTITY_GROUP"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_CILNwBNYEeiKtYjI8wVF7A" name="MAINTENANCE_ENTITY"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_EpIHkBNYEeiKtYjI8wVF7A" name="MEG_END_POINT"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_GI_-4BNYEeiKtYjI8wVF7A" name="MEG_INTERMEDIATE_POINT"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vV3I0BNYEeiKtYjI8wVF7A" name="SWITCH_CONTROL"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_wPccMBNYEeiKtYjI8wVF7A" name="SWITCH"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_xSSZQBNYEeiKtYjI8wVF7A" name="ROUTE"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_MKoKIBNYEeiKtYjI8wVF7A" name="NODE_RULE_GROUP"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Na--wBNYEeiKtYjI8wVF7A" name="INTER_RULE_GROUP"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_tPnOABNYEeiKtYjI8wVF7A" name="RULE"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_bgwjsCzeEeaYO8M_h7XJ5A" name="SourceIndicator" isLeaf="true">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_ggplICzeEeaYO8M_h7XJ5A" name="RESOURCE_OPERATION"/>

--- a/UML/TapiOdu.notation
+++ b/UML/TapiOdu.notation
@@ -1643,14 +1643,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8TnelUeKEeetffGEmR5xrg" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_4xMEMEeLEeetffGEmR5xrg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_4xMEMUeLEeetffGEmR5xrg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4xMEM0eLEeetffGEmR5xrg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_dvFv0EeLEeetffGEmR5xrg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4xMEMkeLEeetffGEmR5xrg" x="477" y="-404"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_8dQhcGZEEeeGDK6oTuc93w" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_8dQhcWZEEeeGDK6oTuc93w" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8dQhc2ZEEeeGDK6oTuc93w" name="BASE_ELEMENT">
@@ -2959,14 +2951,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x1L5co2qEeeyQ71bxGIq2A" x="8" y="-423"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_vnLXgY2vEeeyQ71bxGIq2A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_vnLXgo2vEeeyQ71bxGIq2A" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_vnLXhI2vEeeyQ71bxGIq2A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_f4FBYI2vEeeyQ71bxGIq2A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vnLXg42vEeeyQ71bxGIq2A" x="341" y="-429"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_sCEvQI5CEeeXQ5UBIdOSXw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_sCEvQY5CEeeXQ5UBIdOSXw" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_sCEvQ45CEeeXQ5UBIdOSXw" name="BASE_ELEMENT">
@@ -3453,14 +3437,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Mo9DtZRKEee0N_ppE1lIiw" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Zcj5E5RKEee0N_ppE1lIiw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Zcj5FJRKEee0N_ppE1lIiw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Zcj5FpRKEee0N_ppE1lIiw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_SHJxwJRKEee0N_ppE1lIiw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zcj5FZRKEee0N_ppE1lIiw" x="256" y="-434"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_ZvQncJSeEeeTcuZP_vjYKw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_ZvQncZSeEeeTcuZP_vjYKw" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZvROgJSeEeeTcuZP_vjYKw" name="BASE_ELEMENT">
@@ -3652,6 +3628,78 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_26rxwhJ_Eeix4OZk6OGmSg" x="-52" y="-429"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_O3WmYBNpEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_O3WmYRNpEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_O3WmYxNpEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxiwR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O3WmYhNpEeiod932A6hg3A" x="208" y="-68"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_O5rhoxNpEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_O5rhpBNpEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_O5rhphNpEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_sYw7sR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O5rhpRNpEeiod932A6hg3A" x="256" y="-434"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_O7NysxNpEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_O7NytBNpEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_O7NythNpEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_CJrDMDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O7NytRNpEeiod932A6hg3A" x="-42" y="-54"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_O8dI0xNpEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_O8dI1BNpEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_O8dI1hNpEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_cOYiQDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O8dI1RNpEeiod932A6hg3A" x="-52" y="-429"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Ij09YxNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Ij09ZBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ij09ZhNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_cOYiQDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ij09ZRNqEeiod932A6hg3A" x="-52" y="-429"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_KIRLoxNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_KIRLpBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KIRLphNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_sYw7sR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KIRLpRNqEeiod932A6hg3A" x="256" y="-434"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_LXNrAxNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_LXNrBBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LXNrBhNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_f4FBYI2vEeeyQ71bxGIq2A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LXNrBRNqEeiod932A6hg3A" x="256" y="-434"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_M9WiYxNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_M9WiZBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_M9WiZhNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_dvFv0EeLEeetffGEmR5xrg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M9WiZRNqEeiod932A6hg3A" x="256" y="-434"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OhKegxNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OhKehBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OhKehhNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_SHJxwJRKEee0N_ppE1lIiw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OhKehRNqEeiod932A6hg3A" x="256" y="-434"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_sZDP5B3BEea2UIYIpgn3Zw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_sZDP5R3BEea2UIYIpgn3Zw"/>
@@ -5106,16 +5154,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dzH7QEeLEeetffGEmR5xrg" id="(0.7758241758241758,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dzH7QUeLEeetffGEmR5xrg" id="(0.31666666666666665,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_4xMENEeLEeetffGEmR5xrg" type="StereotypeCommentLink" source="_dwCyEEeLEeetffGEmR5xrg" target="_4xMEMEeLEeetffGEmR5xrg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_4xMENUeLEeetffGEmR5xrg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4xNSUEeLEeetffGEmR5xrg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_dvFv0EeLEeetffGEmR5xrg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4xMENkeLEeetffGEmR5xrg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4xMrQEeLEeetffGEmR5xrg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4xMrQUeLEeetffGEmR5xrg"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_8dRIgGZEEeeGDK6oTuc93w" type="StereotypeCommentLink" source="_sYz_AR3BEea2UIYIpgn3Zw" target="_8dQhcGZEEeeGDK6oTuc93w">
       <styles xmi:type="notation:FontStyle" xmi:id="_8dRIgWZEEeeGDK6oTuc93w"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8dRIhWZEEeeGDK6oTuc93w" name="BASE_ELEMENT">
@@ -6304,16 +6342,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f_GPYI2vEeeyQ71bxGIq2A" id="(0.5714285714285714,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f_GPYY2vEeeyQ71bxGIq2A" id="(0.549520766773163,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_vnLXhY2vEeeyQ71bxGIq2A" type="StereotypeCommentLink" source="_f6jGkI2vEeeyQ71bxGIq2A" target="_vnLXgY2vEeeyQ71bxGIq2A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_vnLXho2vEeeyQ71bxGIq2A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_vnL-kI2vEeeyQ71bxGIq2A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_f4FBYI2vEeeyQ71bxGIq2A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_vnLXh42vEeeyQ71bxGIq2A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vnLXiI2vEeeyQ71bxGIq2A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vnLXiY2vEeeyQ71bxGIq2A"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_sCFWUI5CEeeXQ5UBIdOSXw" type="StereotypeCommentLink" source="_sYz_AR3BEea2UIYIpgn3Zw" target="_sCEvQI5CEeeXQ5UBIdOSXw">
       <styles xmi:type="notation:FontStyle" xmi:id="_sCFWUY5CEeeXQ5UBIdOSXw"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_sCF9Yo5CEeeXQ5UBIdOSXw" name="BASE_ELEMENT">
@@ -6909,16 +6937,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SLI54JRKEee0N_ppE1lIiw" id="(0.9494505494505494,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SLI54ZRKEee0N_ppE1lIiw" id="(0.024291497975708502,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Zcj5F5RKEee0N_ppE1lIiw" type="StereotypeCommentLink" source="_SIAtYJRKEee0N_ppE1lIiw" target="_Zcj5E5RKEee0N_ppE1lIiw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Zcj5GJRKEee0N_ppE1lIiw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZcluQJRKEee0N_ppE1lIiw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_SHJxwJRKEee0N_ppE1lIiw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Zcj5GZRKEee0N_ppE1lIiw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zcj5GpRKEee0N_ppE1lIiw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zcj5G5RKEee0N_ppE1lIiw"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ZvR1kJSeEeeTcuZP_vjYKw" type="StereotypeCommentLink" source="_sYz_AR3BEea2UIYIpgn3Zw" target="_ZvQncJSeEeeTcuZP_vjYKw">
       <styles xmi:type="notation:FontStyle" xmi:id="_ZvR1kZSeEeeTcuZP_vjYKw"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZvR1lZSeEeeTcuZP_vjYKw" name="BASE_ELEMENT">
@@ -7158,6 +7176,96 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_26rxxhJ_Eeix4OZk6OGmSg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_26rxxxJ_Eeix4OZk6OGmSg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_26rxyBJ_Eeix4OZk6OGmSg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_O3WmZBNpEeiod932A6hg3A" type="StereotypeCommentLink" source="_sYz_AR3BEea2UIYIpgn3Zw" target="_O3WmYBNpEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_O3WmZRNpEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_O3WmaRNpEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxiwR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_O3WmZhNpEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O3WmZxNpEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O3WmaBNpEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_O5rhpxNpEeiod932A6hg3A" type="StereotypeCommentLink" source="_sZDP5x3BEea2UIYIpgn3Zw" target="_O5rhoxNpEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_O5rhqBNpEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_O5rhrBNpEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_sYw7sR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_O5rhqRNpEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O5rhqhNpEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O5rhqxNpEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_O7NytxNpEeiod932A6hg3A" type="StereotypeCommentLink" source="_C8QWsDIOEeaBg9FoTfINnA" target="_O7NysxNpEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_O7NyuBNpEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_O7T5UhNpEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_CJrDMDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_O7NyuRNpEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O7T5UBNpEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O7T5URNpEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_O8dI1xNpEeiod932A6hg3A" type="StereotypeCommentLink" source="_cO-YIDIOEeaBg9FoTfINnA" target="_O8dI0xNpEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_O8dI2BNpEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_O8dI3BNpEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_cOYiQDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_O8dI2RNpEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O8dI2hNpEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O8dI2xNpEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Ij09ZxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_cO-YIDIOEeaBg9FoTfINnA" target="_Ij09YxNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Ij09aBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ij7EABNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_cOYiQDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ij09aRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ij09ahNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ij09axNqEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_KIRLpxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_sZDP5x3BEea2UIYIpgn3Zw" target="_KIRLoxNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_KIRLqBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KIRLrBNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_sYw7sR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KIRLqRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KIRLqhNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KIRLqxNqEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_LXNrBxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_f6jGkI2vEeeyQ71bxGIq2A" target="_LXNrAxNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_LXNrCBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_LXNrDBNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_f4FBYI2vEeeyQ71bxGIq2A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LXNrCRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LXNrChNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LXNrCxNqEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_M9WiZxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_dwCyEEeLEeetffGEmR5xrg" target="_M9WiYxNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_M9WiaBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_M9WibBNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_dvFv0EeLEeetffGEmR5xrg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_M9WiaRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_M9WiahNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_M9WiaxNqEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_OhKehxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_SIAtYJRKEee0N_ppE1lIiw" target="_OhKegxNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OhKeiBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OhKejBNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_SHJxwJRKEee0N_ppE1lIiw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OhKeiRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OhKeihNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OhKeixNqEeiod932A6hg3A"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_lW6NAJQPEeebLvYqX3NA2Q" type="PapyrusUMLClassDiagram" name="OduOamSpec" measurementUnit="Pixel">
@@ -7431,14 +7539,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1NwUdZQQEeebLvYqX3NA2Q" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_EJsvU5QREeebLvYqX3NA2Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_EJsvVJQREeebLvYqX3NA2Q" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EJsvVpQREeebLvYqX3NA2Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_24Bd4JQQEeebLvYqX3NA2Q"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EJsvVZQREeebLvYqX3NA2Q" x="871" y="82"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_IdF3IJQREeebLvYqX3NA2Q" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_IdGeMJQREeebLvYqX3NA2Q" type="5029"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_IdGeMZQREeebLvYqX3NA2Q" type="8510">
@@ -7476,14 +7576,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IdUgpZQREeebLvYqX3NA2Q" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Id8Ls5QREeebLvYqX3NA2Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Id8LtJQREeebLvYqX3NA2Q" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Id8LtpQREeebLvYqX3NA2Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_Kll8QIzgEeeZS7Bq2RfTZA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Id8LtZQREeebLvYqX3NA2Q" x="336" y="329"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_L8RTwJQREeebLvYqX3NA2Q" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_L8R60JQREeebLvYqX3NA2Q" type="5029"/>
@@ -7551,14 +7643,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_L8jAkpQREeebLvYqX3NA2Q" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_L9bKUJQREeebLvYqX3NA2Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_L9bKUZQREeebLvYqX3NA2Q" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_L9bKU5QREeebLvYqX3NA2Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_J7cMAIzgEeeZS7Bq2RfTZA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_L9bKUpQREeebLvYqX3NA2Q" x="565" y="433"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="__HUlIJQREeebLvYqX3NA2Q" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="__HUlIpQREeebLvYqX3NA2Q" type="5029"/>
       <children xmi:type="notation:DecorationNode" xmi:id="__HUlI5QREeebLvYqX3NA2Q" type="8510">
@@ -7596,22 +7680,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Har1JQREeebLvYqX3NA2Q" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_KUu4wJQSEeebLvYqX3NA2Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_KUu4wZQSEeebLvYqX3NA2Q" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KUu4w5QSEeebLvYqX3NA2Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_CfokwJQSEeebLvYqX3NA2Q"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KUu4wpQSEeebLvYqX3NA2Q" x="871" y="82"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_MQ978JQSEeebLvYqX3NA2Q" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MQ978ZQSEeebLvYqX3NA2Q" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MQ9785QSEeebLvYqX3NA2Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_C8ff4JQSEeebLvYqX3NA2Q"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MQ978pQSEeebLvYqX3NA2Q" x="871" y="82"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_sIDPMJRHEee0N_ppE1lIiw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_sIEdUJRHEee0N_ppE1lIiw" type="5029"/>
@@ -7686,14 +7754,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sINnR5RHEee0N_ppE1lIiw" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_fDEggJRIEee0N_ppE1lIiw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_fDEggZRIEee0N_ppE1lIiw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fDEgg5RIEee0N_ppE1lIiw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_u4KmYJRHEee0N_ppE1lIiw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fDEggpRIEee0N_ppE1lIiw" x="373" y="71"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_c-AP0JSoEeeTcuZP_vjYKw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_c-FvYJSoEeeTcuZP_vjYKw" type="5029"/>
@@ -7855,37 +7915,85 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_naqa9JSzEeeTcuZP_vjYKw" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_DU6_A5S3EeeTcuZP_vjYKw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_DU6_BJS3EeeTcuZP_vjYKw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DU6_BpS3EeeTcuZP_vjYKw" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_Rk6jYxNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Rk6jZBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Rk6jZhNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_u4KmYJRHEee0N_ppE1lIiw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Rk6jZRNqEeiod932A6hg3A" x="373" y="46"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_S1lhExNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_S1lhFBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_S1lhFhNqEeiod932A6hg3A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_AeHmcJS2EeeTcuZP_vjYKw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DU6_BZS3EeeTcuZP_vjYKw" x="373" y="71"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_S1lhFRNqEeiod932A6hg3A" x="373" y="46"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_OEgHI5S3EeeTcuZP_vjYKw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_OEgHJJS3EeeTcuZP_vjYKw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OEgHJpS3EeeTcuZP_vjYKw" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_UaBIQxNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UaBIRBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UaBIRhNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_J7cMAIzgEeeZS7Bq2RfTZA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UaBIRRNqEeiod932A6hg3A" x="486" y="289"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_WdW5AxNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WdW5BBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WdW5BhNqEeiod932A6hg3A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_BDztcJS2EeeTcuZP_vjYKw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OEgHJZS3EeeTcuZP_vjYKw" x="373" y="71"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WdW5BRNqEeiod932A6hg3A" x="373" y="46"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_P_wS4JS3EeeTcuZP_vjYKw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_P_wS4ZS3EeeTcuZP_vjYKw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P_wS45S3EeeTcuZP_vjYKw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#__wbaAJS1EeeTcuZP_vjYKw"/>
+    <children xmi:type="notation:Shape" xmi:id="_XvgdYxNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_XvgdZBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XvgdZhNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_Kll8QIzgEeeZS7Bq2RfTZA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P_wS4pS3EeeTcuZP_vjYKw" x="987" y="75"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XvgdZRNqEeiod932A6hg3A" x="789" y="299"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_bord05S3EeeTcuZP_vjYKw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_bord1JS3EeeTcuZP_vjYKw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bord1pS3EeeTcuZP_vjYKw" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_bFqg4xNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bFqg5BNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bFqg5hNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_CfokwJQSEeebLvYqX3NA2Q"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bFqg5RNqEeiod932A6hg3A" x="987" y="50"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_cmk6AxNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_cmk6BBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cmk6BhNqEeiod932A6hg3A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_B2-PwJS2EeeTcuZP_vjYKw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bord1ZS3EeeTcuZP_vjYKw" x="987" y="75"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cmk6BRNqEeiod932A6hg3A" x="987" y="50"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_d8wCwxNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_d8wCxBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_d8wCxhNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_C8ff4JQSEeebLvYqX3NA2Q"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d8wCxRNqEeiod932A6hg3A" x="987" y="50"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_faEVUxNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_faEVVBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_faEVVhNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#__wbaAJS1EeeTcuZP_vjYKw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_faEVVRNqEeiod932A6hg3A" x="987" y="50"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gxiekxNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_gxielBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gxielhNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_24Bd4JQQEeebLvYqX3NA2Q"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gxielRNqEeiod932A6hg3A" x="987" y="50"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_lW6NAZQPEeebLvYqX3NA2Q" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_lW6NApQPEeebLvYqX3NA2Q"/>
@@ -8054,16 +8162,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_25KtYJQQEeebLvYqX3NA2Q" id="(0.921875,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_25KtYZQQEeebLvYqX3NA2Q" id="(0.1506276150627615,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_EJsvV5QREeebLvYqX3NA2Q" type="StereotypeCommentLink" source="_24YqQJQQEeebLvYqX3NA2Q" target="_EJsvU5QREeebLvYqX3NA2Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_EJsvWJQREeebLvYqX3NA2Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EJsvXJQREeebLvYqX3NA2Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_24Bd4JQQEeebLvYqX3NA2Q"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EJsvWZQREeebLvYqX3NA2Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EJsvWpQREeebLvYqX3NA2Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EJsvW5QREeebLvYqX3NA2Q"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_IdUgp5QREeebLvYqX3NA2Q" type="StereotypeCommentLink" source="_IdF3IJQREeebLvYqX3NA2Q" target="_IdUgo5QREeebLvYqX3NA2Q">
       <styles xmi:type="notation:FontStyle" xmi:id="_IdUgqJQREeebLvYqX3NA2Q"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_IdUgrJQREeebLvYqX3NA2Q" name="BASE_ELEMENT">
@@ -8099,16 +8197,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IdtiP5QREeebLvYqX3NA2Q" id="(0.35960591133004927,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IdtiQJQREeebLvYqX3NA2Q" id="(0.8619854721549637,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Id8Lt5QREeebLvYqX3NA2Q" type="StereotypeCommentLink" source="_IdtiMJQREeebLvYqX3NA2Q" target="_Id8Ls5QREeebLvYqX3NA2Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Id8LuJQREeebLvYqX3NA2Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Id8ywpQREeebLvYqX3NA2Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_Kll8QIzgEeeZS7Bq2RfTZA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Id8LuZQREeebLvYqX3NA2Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Id8ywJQREeebLvYqX3NA2Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Id8ywZQREeebLvYqX3NA2Q"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_L8jAlJQREeebLvYqX3NA2Q" type="StereotypeCommentLink" source="_L8RTwJQREeebLvYqX3NA2Q" target="_L8jAkJQREeebLvYqX3NA2Q">
       <styles xmi:type="notation:FontStyle" xmi:id="_L8jAlZQREeebLvYqX3NA2Q"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_L8jAmZQREeebLvYqX3NA2Q" name="BASE_ELEMENT">
@@ -8143,16 +8231,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_L9HBQpQREeebLvYqX3NA2Q" points="[72, 0, 0, 118]$[72, -118, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_L9HBT5QREeebLvYqX3NA2Q" id="(0.19852941176470587,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_L9HBUJQREeebLvYqX3NA2Q" id="(0.5786924939467313,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_L9bKVJQREeebLvYqX3NA2Q" type="StereotypeCommentLink" source="_L9HBQJQREeebLvYqX3NA2Q" target="_L9bKUJQREeebLvYqX3NA2Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_L9bKVZQREeebLvYqX3NA2Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_L9bKWZQREeebLvYqX3NA2Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_J7cMAIzgEeeZS7Bq2RfTZA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_L9bKVpQREeebLvYqX3NA2Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_L9bKV5QREeebLvYqX3NA2Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_L9bKWJQREeebLvYqX3NA2Q"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__HbS0ZQREeebLvYqX3NA2Q" type="StereotypeCommentLink" source="__HUlIJQREeebLvYqX3NA2Q" target="__Har0pQREeebLvYqX3NA2Q">
       <styles xmi:type="notation:FontStyle" xmi:id="__HbS0pQREeebLvYqX3NA2Q"/>
@@ -8214,26 +8292,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_C-Ai0JQSEeebLvYqX3NA2Q" id="(0.875,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_C-Ai0ZQSEeebLvYqX3NA2Q" id="(0.1871345029239766,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_KUu4xJQSEeebLvYqX3NA2Q" type="StereotypeCommentLink" source="_CgEpoJQSEeebLvYqX3NA2Q" target="_KUu4wJQSEeebLvYqX3NA2Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_KUu4xZQSEeebLvYqX3NA2Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_KUu4yZQSEeebLvYqX3NA2Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_CfokwJQSEeebLvYqX3NA2Q"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KUu4xpQSEeebLvYqX3NA2Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KUu4x5QSEeebLvYqX3NA2Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KUu4yJQSEeebLvYqX3NA2Q"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MQ979JQSEeebLvYqX3NA2Q" type="StereotypeCommentLink" source="_C8-BAJQSEeebLvYqX3NA2Q" target="_MQ978JQSEeebLvYqX3NA2Q">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MQ979ZQSEeebLvYqX3NA2Q"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MQ97-ZQSEeebLvYqX3NA2Q" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_C8ff4JQSEeebLvYqX3NA2Q"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MQ979pQSEeebLvYqX3NA2Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MQ9795QSEeebLvYqX3NA2Q"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MQ97-JQSEeebLvYqX3NA2Q"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_sINnSZRHEee0N_ppE1lIiw" type="StereotypeCommentLink" source="_sIDPMJRHEee0N_ppE1lIiw" target="_sINnRZRHEee0N_ppE1lIiw">
       <styles xmi:type="notation:FontStyle" xmi:id="_sINnSpRHEee0N_ppE1lIiw"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_sINnTpRHEee0N_ppE1lIiw" name="BASE_ELEMENT">
@@ -8268,16 +8326,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_u5YuYpRHEee0N_ppE1lIiw" points="[-303, 0, 157, -119]$[-303, 119, 157, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u7ve0JRHEee0N_ppE1lIiw" id="(0.7601246105919003,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u7ve0ZRHEee0N_ppE1lIiw" id="(0.044897959183673466,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_fDEghJRIEee0N_ppE1lIiw" type="StereotypeCommentLink" source="_u5YuYJRHEee0N_ppE1lIiw" target="_fDEggJRIEee0N_ppE1lIiw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_fDEghZRIEee0N_ppE1lIiw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fDEgiZRIEee0N_ppE1lIiw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_u4KmYJRHEee0N_ppE1lIiw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fDEghpRIEee0N_ppE1lIiw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fDEgh5RIEee0N_ppE1lIiw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fDEgiJRIEee0N_ppE1lIiw"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_c-wdx5SoEeeTcuZP_vjYKw" type="StereotypeCommentLink" source="_c-AP0JSoEeeTcuZP_vjYKw" target="_c-wdw5SoEeeTcuZP_vjYKw">
       <styles xmi:type="notation:FontStyle" xmi:id="_c-wdyJSoEeeTcuZP_vjYKw"/>
@@ -8459,45 +8507,105 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B7LaUJS2EeeTcuZP_vjYKw" id="(0.4192708333333333,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B7LaUZS2EeeTcuZP_vjYKw" id="(0.56353591160221,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_DU6_B5S3EeeTcuZP_vjYKw" type="StereotypeCommentLink" source="_AfI6IJS2EeeTcuZP_vjYKw" target="_DU6_A5S3EeeTcuZP_vjYKw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_DU6_CJS3EeeTcuZP_vjYKw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DU6_DJS3EeeTcuZP_vjYKw" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_Rk6jZxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_u5YuYJRHEee0N_ppE1lIiw" target="_Rk6jYxNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Rk6jaBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Rk6jbBNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_u4KmYJRHEee0N_ppE1lIiw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Rk6jaRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Rk6jahNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Rk6jaxNqEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_S1lhFxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_AfI6IJS2EeeTcuZP_vjYKw" target="_S1lhExNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_S1lhGBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_S1lhHBNqEeiod932A6hg3A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_AeHmcJS2EeeTcuZP_vjYKw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DU6_CZS3EeeTcuZP_vjYKw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DU6_CpS3EeeTcuZP_vjYKw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DU6_C5S3EeeTcuZP_vjYKw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_S1lhGRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_S1lhGhNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_S1lhGxNqEeiod932A6hg3A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_OEgHJ5S3EeeTcuZP_vjYKw" type="StereotypeCommentLink" source="_BEx90JS2EeeTcuZP_vjYKw" target="_OEgHI5S3EeeTcuZP_vjYKw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_OEgHKJS3EeeTcuZP_vjYKw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OEgHLJS3EeeTcuZP_vjYKw" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_UaBIRxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_L9HBQJQREeebLvYqX3NA2Q" target="_UaBIQxNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UaBISBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UaBITBNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_J7cMAIzgEeeZS7Bq2RfTZA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UaBISRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UaBIShNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UaBISxNqEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WdW5BxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_BEx90JS2EeeTcuZP_vjYKw" target="_WdW5AxNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WdW5CBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WdW5DBNqEeiod932A6hg3A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_BDztcJS2EeeTcuZP_vjYKw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OEgHKZS3EeeTcuZP_vjYKw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OEgHKpS3EeeTcuZP_vjYKw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OEgHK5S3EeeTcuZP_vjYKw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WdW5CRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WdW5ChNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WdW5CxNqEeiod932A6hg3A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_P_wS5JS3EeeTcuZP_vjYKw" type="StereotypeCommentLink" source="__xdUwJS1EeeTcuZP_vjYKw" target="_P_wS4JS3EeeTcuZP_vjYKw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_P_wS5ZS3EeeTcuZP_vjYKw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_P_wS6ZS3EeeTcuZP_vjYKw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#__wbaAJS1EeeTcuZP_vjYKw"/>
+    <edges xmi:type="notation:Connector" xmi:id="_XvgdZxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_IdtiMJQREeebLvYqX3NA2Q" target="_XvgdYxNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_XvgdaBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XvgdbBNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_Kll8QIzgEeeZS7Bq2RfTZA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P_wS5pS3EeeTcuZP_vjYKw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P_wS55S3EeeTcuZP_vjYKw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_P_wS6JS3EeeTcuZP_vjYKw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XvgdaRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XvgdahNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XvgdaxNqEeiod932A6hg3A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bosE4JS3EeeTcuZP_vjYKw" type="StereotypeCommentLink" source="_B3-8YJS2EeeTcuZP_vjYKw" target="_bord05S3EeeTcuZP_vjYKw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_bosE4ZS3EeeTcuZP_vjYKw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bosE5ZS3EeeTcuZP_vjYKw" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_bFqg5xNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_CgEpoJQSEeebLvYqX3NA2Q" target="_bFqg4xNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bFqg6BNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bFqg7BNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_CfokwJQSEeebLvYqX3NA2Q"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bFqg6RNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bFqg6hNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bFqg6xNqEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_cmk6BxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_B3-8YJS2EeeTcuZP_vjYKw" target="_cmk6AxNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_cmk6CBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cmk6DBNqEeiod932A6hg3A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_B2-PwJS2EeeTcuZP_vjYKw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bosE4pS3EeeTcuZP_vjYKw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bosE45S3EeeTcuZP_vjYKw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bosE5JS3EeeTcuZP_vjYKw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cmk6CRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cmk6ChNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cmk6CxNqEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_d8wCxxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_C8-BAJQSEeebLvYqX3NA2Q" target="_d8wCwxNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_d8wCyBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_d8wCzBNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_C8ff4JQSEeebLvYqX3NA2Q"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_d8wCyRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d8wCyhNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d8wCyxNqEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_faEVVxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="__xdUwJS1EeeTcuZP_vjYKw" target="_faEVUxNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_faEVWBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_faEVXBNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#__wbaAJS1EeeTcuZP_vjYKw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_faEVWRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_faEVWhNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_faEVWxNqEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_gxielxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_24YqQJQQEeebLvYqX3NA2Q" target="_gxiekxNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_gxiemBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gxienBNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_24Bd4JQQEeebLvYqX3NA2Q"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gxiemRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gxiemhNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gxiemxNqEeiod932A6hg3A"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiOdu.uml
+++ b/UML/TapiOdu.uml
@@ -761,7 +761,6 @@ Number of Errored Blocks is captured in an integer value.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_dq0IokKkEea-2Meh9kw1kA" base_StructuralFeature="_dq0IoEKkEea-2Meh9kw1kA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_iK8r8kKkEea-2Meh9kw1kA" base_StructuralFeature="_iK8r8EKkEea-2Meh9kw1kA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_knwsoEKkEea-2Meh9kw1kA" base_StructuralFeature="_knm7oEKkEea-2Meh9kw1kA"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_1XOgIEUAEead1bezhJG4aw" base_Association="_cOYiQDIOEeaBg9FoTfINnA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_UoKjwEKhEea-2Meh9kw1kA" base_Class="_Um-Q8EKhEea-2Meh9kw1kA" support="CONDITIONAL_MANDATORY" condition="ODU"/>
   <OpenModel_Profile:Specify xmi:id="_YmwUABNJEeeQQtMBY9ly8w" base_Abstraction="_QeB5YBNJEeeQQtMBY9ly8w">
     <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_ownedNodeEdgePoint</target>
@@ -778,7 +777,6 @@ Number of Errored Blocks is captured in an integer value.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_dvHlAEeLEeetffGEmR5xrg" base_Property="_dvGW4keLEeetffGEmR5xrg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_dvIMEEeLEeetffGEmR5xrg" base_StructuralFeature="_dvHlAUeLEeetffGEmR5xrg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_dvIMEUeLEeetffGEmR5xrg" base_Property="_dvHlAUeLEeetffGEmR5xrg"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_4xBsIEeLEeetffGEmR5xrg" base_Association="_dvFv0EeLEeetffGEmR5xrg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_HdpcIEeNEeetffGEmR5xrg" base_StructuralFeature="_ti488JhkEeCkc9Q1fLoutg" isInvariant="true"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_HdqqQEeNEeetffGEmR5xrg" base_Property="_ti488JhkEeCkc9Q1fLoutg" writeAllowed="WRITE_NOT_ALLOWED"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_I7CxwUeOEeetffGEmR5xrg" base_Class="_I7CxwEeOEeetffGEmR5xrg" support="CONDITIONAL_MANDATORY" condition="ODU"/>
@@ -872,14 +870,10 @@ Number of Errored Blocks is captured in an integer value.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_KlmjUozgEeeZS7Bq2RfTZA" base_Property="_KlmjUIzgEeeZS7Bq2RfTZA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_KlnKYIzgEeeZS7Bq2RfTZA" base_StructuralFeature="_KlmjU4zgEeeZS7Bq2RfTZA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_KlnKYYzgEeeZS7Bq2RfTZA" base_Property="_KlmjU4zgEeeZS7Bq2RfTZA"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_yrgFMIzgEeeZS7Bq2RfTZA" base_Association="_J7cMAIzgEeeZS7Bq2RfTZA"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_zmTgkIzgEeeZS7Bq2RfTZA" base_Association="_Kll8QIzgEeeZS7Bq2RfTZA"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_WR0ygIzjEeeZS7Bq2RfTZA" base_Association="_sYw7sR3BEea2UIYIpgn3Zw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_f4MWII2vEeeyQ71bxGIq2A" base_StructuralFeature="_f4Kg8I2vEeeyQ71bxGIq2A"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_f4ZKcI2vEeeyQ71bxGIq2A" base_Property="_f4Kg8I2vEeeyQ71bxGIq2A"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_f4ZxgY2vEeeyQ71bxGIq2A" base_StructuralFeature="_f4ZxgI2vEeeyQ71bxGIq2A"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_f4Zxgo2vEeeyQ71bxGIq2A" base_Property="_f4ZxgI2vEeeyQ71bxGIq2A"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_vnECwI2vEeeyQ71bxGIq2A" base_Association="_f4FBYI2vEeeyQ71bxGIq2A"/>
   <OpenModel_Profile:Experimental xmi:id="_wQ8p0I5KEeeXQ5UBIdOSXw" base_Element="_I7CxwEeOEeetffGEmR5xrg"/>
   <OpenModel_Profile:Experimental xmi:id="_yOG6EI5KEeeXQ5UBIdOSXw" base_Element="_VT7jAIHDEeeh4KO3PMo8Rw"/>
   <OpenModel_Profile:Experimental xmi:id="_znRscI5KEeeXQ5UBIdOSXw" base_Element="_P1C4cIHDEeeh4KO3PMo8Rw"/>
@@ -906,7 +900,6 @@ Number of Errored Blocks is captured in an integer value.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_24DTEJQQEeebLvYqX3NA2Q" base_StructuralFeature="_24CE8pQQEeebLvYqX3NA2Q"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_24D6IJQQEeebLvYqX3NA2Q" base_Property="_24DTEZQQEeebLvYqX3NA2Q"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_24D6IZQQEeebLvYqX3NA2Q" base_StructuralFeature="_24DTEZQQEeebLvYqX3NA2Q"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_EJi-UJQREeebLvYqX3NA2Q" base_Association="_24Bd4JQQEeebLvYqX3NA2Q"/>
   <OpenModel_Profile:OpenModelClass xmi:id="__HQTsJQREeebLvYqX3NA2Q" base_Class="__HPsoJQREeebLvYqX3NA2Q"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="__HRh0JQREeebLvYqX3NA2Q" base_Class="__HPsoJQREeebLvYqX3NA2Q"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_CfqZ8JQSEeebLvYqX3NA2Q" base_Property="_Cfpy4JQSEeebLvYqX3NA2Q"/>
@@ -917,8 +910,6 @@ Number of Errored Blocks is captured in an integer value.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_C8h8IJQSEeebLvYqX3NA2Q" base_StructuralFeature="_C8guAJQSEeebLvYqX3NA2Q"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_C8h8IpQSEeebLvYqX3NA2Q" base_Property="_C8h8IZQSEeebLvYqX3NA2Q"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_C8h8I5QSEeebLvYqX3NA2Q" base_StructuralFeature="_C8h8IZQSEeebLvYqX3NA2Q"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_KUm88JQSEeebLvYqX3NA2Q" base_Association="_CfokwJQSEeebLvYqX3NA2Q"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_MQ2nMJQSEeebLvYqX3NA2Q" base_Association="_C8ff4JQSEeebLvYqX3NA2Q"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_7smVQJQSEeebLvYqX3NA2Q" base_Property="_7sluMJQSEeebLvYqX3NA2Q"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_7snjYJQSEeebLvYqX3NA2Q" base_StructuralFeature="_7sluMJQSEeebLvYqX3NA2Q"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_lol2EpQTEeebLvYqX3NA2Q" base_Property="_lol2EJQTEeebLvYqX3NA2Q"/>
@@ -941,12 +932,10 @@ Number of Errored Blocks is captured in an integer value.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_u4SiMJRHEee0N_ppE1lIiw" base_StructuralFeature="_u4QtAJRHEee0N_ppE1lIiw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_u4SiMpRHEee0N_ppE1lIiw" base_Property="_u4SiMZRHEee0N_ppE1lIiw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_u4TwUJRHEee0N_ppE1lIiw" base_StructuralFeature="_u4SiMZRHEee0N_ppE1lIiw"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_fCzawJRIEee0N_ppE1lIiw" base_Association="_u4KmYJRHEee0N_ppE1lIiw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_SHLm8ZRKEee0N_ppE1lIiw" base_Property="_SHLm8JRKEee0N_ppE1lIiw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_SHLm8pRKEee0N_ppE1lIiw" base_StructuralFeature="_SHLm8JRKEee0N_ppE1lIiw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_SHLm9JRKEee0N_ppE1lIiw" base_Property="_SHLm85RKEee0N_ppE1lIiw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_SHLm9ZRKEee0N_ppE1lIiw" base_StructuralFeature="_SHLm85RKEee0N_ppE1lIiw"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_ZcXr0JRKEee0N_ppE1lIiw" base_Association="_SHJxwJRKEee0N_ppE1lIiw"/>
   <OpenModel_Profile:Experimental xmi:id="_HS3TUJRLEee0N_ppE1lIiw" base_Element="__HPsoJQREeebLvYqX3NA2Q"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_MoVYoJRKEee0N_ppE1lIiw" base_Class="_MoTjcJRKEee0N_ppE1lIiw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_MoTjcZRKEee0N_ppE1lIiw" base_Class="_MoTjcJRKEee0N_ppE1lIiw"/>
@@ -1007,8 +996,19 @@ Number of Errored Blocks is captured in an integer value.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_B3AsAJS2EeeTcuZP_vjYKw" base_Property="_B2_d4ZS2EeeTcuZP_vjYKw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_B3BTEZS2EeeTcuZP_vjYKw" base_StructuralFeature="_B3BTEJS2EeeTcuZP_vjYKw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_B3BTEpS2EeeTcuZP_vjYKw" base_Property="_B3BTEJS2EeeTcuZP_vjYKw"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_DU0RUJS3EeeTcuZP_vjYKw" base_Association="_AeHmcJS2EeeTcuZP_vjYKw"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_OEYyYJS3EeeTcuZP_vjYKw" base_Association="_BDztcJS2EeeTcuZP_vjYKw"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_P_plMJS3EeeTcuZP_vjYKw" base_Association="__wbaAJS1EeeTcuZP_vjYKw"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_boi68JS3EeeTcuZP_vjYKw" base_Association="_B2-PwJS2EeeTcuZP_vjYKw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_Iju2wBNqEeiod932A6hg3A" base_Association="_cOYiQDIOEeaBg9FoTfINnA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_KIE-YBNqEeiod932A6hg3A" base_Association="_sYw7sR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_LXHkYBNqEeiod932A6hg3A" base_Association="_f4FBYI2vEeeyQ71bxGIq2A"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_M9QbwBNqEeiod932A6hg3A" base_Association="_dvFv0EeLEeetffGEmR5xrg"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_Og-RQBNqEeiod932A6hg3A" base_Association="_SHJxwJRKEee0N_ppE1lIiw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_Rk0cwBNqEeiod932A6hg3A" base_Association="_u4KmYJRHEee0N_ppE1lIiw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_S1facBNqEeiod932A6hg3A" base_Association="_AeHmcJS2EeeTcuZP_vjYKw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_UZ7BoBNqEeiod932A6hg3A" base_Association="_J7cMAIzgEeeZS7Bq2RfTZA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_WdQyYBNqEeiod932A6hg3A" base_Association="_BDztcJS2EeeTcuZP_vjYKw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_XvaWwBNqEeiod932A6hg3A" base_Association="_Kll8QIzgEeeZS7Bq2RfTZA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_bFkaQBNqEeiod932A6hg3A" base_Association="_CfokwJQSEeebLvYqX3NA2Q"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_cmYswBNqEeiod932A6hg3A" base_Association="_B2-PwJS2EeeTcuZP_vjYKw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_d8p8IBNqEeiod932A6hg3A" base_Association="_C8ff4JQSEeebLvYqX3NA2Q"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_fZyBcBNqEeiod932A6hg3A" base_Association="__wbaAJS1EeeTcuZP_vjYKw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_gxcX8BNqEeiod932A6hg3A" base_Association="_24Bd4JQQEeebLvYqX3NA2Q"/>
 </xmi:XMI>

--- a/UML/TapiOtsi.notation
+++ b/UML/TapiOtsi.notation
@@ -625,14 +625,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0uD_oo6dEeeyZasfnNSonw" x="14" y="-385"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_0vN2MI6dEeeyZasfnNSonw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_0vN2MY6dEeeyZasfnNSonw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0vN2M46dEeeyZasfnNSonw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_KjQ3ohKOEeajhbtskMXJfw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0vN2Mo6dEeeyZasfnNSonw" x="372" y="-387"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_0vTVwI6dEeeyZasfnNSonw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_0vTVwY6dEeeyZasfnNSonw" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0vTVw46dEeeyZasfnNSonw" name="BASE_ELEMENT">
@@ -640,22 +632,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0vTVwo6dEeeyZasfnNSonw" x="372" y="-387"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_0v7A0I6dEeeyZasfnNSonw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_0v7A0Y6dEeeyZasfnNSonw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0v7A046dEeeyZasfnNSonw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0v7A0o6dEeeyZasfnNSonw" x="13" y="-238"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_uGxtI46eEeeyZasfnNSonw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_uGxtJI6eEeeyZasfnNSonw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uGxtJo6eEeeyZasfnNSonw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_2YPCcI6dEeeyZasfnNSonw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uGxtJY6eEeeyZasfnNSonw" x="372" y="-387"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_rJyhsI8ZEeedErNofqJXiw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_rJyhsY8ZEeedErNofqJXiw" showTitle="true"/>
@@ -721,13 +697,117 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rPVwEo8ZEeedErNofqJXiw" x="13" y="-138"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_HMdrQ84xEeehIvzuBRCtZQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_HMdrRM4xEeehIvzuBRCtZQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_HMdrRs4xEeehIvzuBRCtZQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_odv8UxNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_odv8VBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_odv8VhNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_odv8VRNqEeiod932A6hg3A" x="13" y="-238"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_pnWBoxNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_pnWBpBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pnWBphNqEeiod932A6hg3A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_KjQ3phKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HMdrRc4xEeehIvzuBRCtZQ" x="372" y="-419"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pnWBpRNqEeiod932A6hg3A" x="372" y="-419"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_q2fVUxNqEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_q2fVVBNqEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_q2fVVhNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_KjQ3ohKOEeajhbtskMXJfw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q2fVVRNqEeiod932A6hg3A" x="372" y="-419"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_D20w0xNsEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_D20w1BNsEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D20w1hNsEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_2YPCcI6dEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_D20w1RNsEeiod932A6hg3A" x="372" y="-419"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ptHnkBNsEeiod932A6hg3A" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ptNuMBNsEeiod932A6hg3A" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ptNuMRNsEeiod932A6hg3A" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ptNuMhNsEeiod932A6hg3A" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ptNuMxNsEeiod932A6hg3A" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ptNuNBNsEeiod932A6hg3A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ptNuNRNsEeiod932A6hg3A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ptNuNhNsEeiod932A6hg3A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ptNuNxNsEeiod932A6hg3A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ptNuOBNsEeiod932A6hg3A" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ptNuORNsEeiod932A6hg3A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ptNuOhNsEeiod932A6hg3A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ptNuOxNsEeiod932A6hg3A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ptNuPBNsEeiod932A6hg3A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ptNuPRNsEeiod932A6hg3A" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ptNuPhNsEeiod932A6hg3A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ptNuPxNsEeiod932A6hg3A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ptNuQBNsEeiod932A6hg3A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ptNuQRNsEeiod932A6hg3A"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_k96BsIfbEeeirpBaj87qAw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ptHnkRNsEeiod932A6hg3A" x="753" y="-461"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ptZ7cxNsEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ptZ7dBNsEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ptZ7dhNsEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_k96BsIfbEeeirpBaj87qAw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ptZ7dRNsEeiod932A6hg3A" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yU8ZABNsEeiod932A6hg3A" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_yU8ZAhNsEeiod932A6hg3A" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_yU8ZAxNsEeiod932A6hg3A" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_yU8ZBBNsEeiod932A6hg3A" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_yU8ZBRNsEeiod932A6hg3A" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_zQZ7sBNsEeiod932A6hg3A" type="3012">
+          <element xmi:type="uml:Property" href="TapiOtsi.uml#_jtfbUIfeEeet-8tHdGGp_w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_zQZ7sRNsEeiod932A6hg3A"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_yU8ZBhNsEeiod932A6hg3A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_yU8ZBxNsEeiod932A6hg3A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_yU8ZCBNsEeiod932A6hg3A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yU8ZCRNsEeiod932A6hg3A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_yU8ZChNsEeiod932A6hg3A" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_yU8ZCxNsEeiod932A6hg3A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_yU8ZDBNsEeiod932A6hg3A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_yU8ZDRNsEeiod932A6hg3A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yU8ZDhNsEeiod932A6hg3A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_yU8ZDxNsEeiod932A6hg3A" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_yU8ZEBNsEeiod932A6hg3A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_yU8ZERNsEeiod932A6hg3A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_yU8ZEhNsEeiod932A6hg3A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yU8ZExNsEeiod932A6hg3A"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOtsi.uml#_YS8DkIfeEeet-8tHdGGp_w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yU8ZARNsEeiod932A6hg3A" x="714" y="-256" width="317" height="89"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_yVImUhNsEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_yVImUxNsEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yVImVRNsEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOtsi.uml#_YS8DkIfeEeet-8tHdGGp_w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yVImVBNsEeiod932A6hg3A" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_49mIAxNsEeiod932A6hg3A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_49mIBBNsEeiod932A6hg3A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_49mIBhNsEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOtsi.uml#_7OKQUIfeEeet-8tHdGGp_w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_49mIBRNsEeiod932A6hg3A" x="922" y="-413"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_z6FlAY6dEeeyZasfnNSonw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_z6FlAo6dEeeyZasfnNSonw"/>
@@ -849,16 +929,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0uEms46dEeeyZasfnNSonw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0uEmtI6dEeeyZasfnNSonw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_0vN2NI6dEeeyZasfnNSonw" type="StereotypeCommentLink" source="_0s_BpY6dEeeyZasfnNSonw" target="_0vN2MI6dEeeyZasfnNSonw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_0vN2NY6dEeeyZasfnNSonw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0vN2OY6dEeeyZasfnNSonw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_KjQ3ohKOEeajhbtskMXJfw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0vN2No6dEeeyZasfnNSonw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0vN2N46dEeeyZasfnNSonw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0vN2OI6dEeeyZasfnNSonw"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0vT80I6dEeeyZasfnNSonw" type="StereotypeCommentLink" source="_0s9MYo6dEeeyZasfnNSonw" target="_0vTVwI6dEeeyZasfnNSonw">
       <styles xmi:type="notation:FontStyle" xmi:id="_0vT80Y6dEeeyZasfnNSonw"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0vT81Y6dEeeyZasfnNSonw" name="BASE_ELEMENT">
@@ -868,16 +938,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0vT80o6dEeeyZasfnNSonw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0vT8046dEeeyZasfnNSonw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0vT81I6dEeeyZasfnNSonw"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_0v7A1I6dEeeyZasfnNSonw" type="StereotypeCommentLink" source="_0smADY6dEeeyZasfnNSonw" target="_0v7A0I6dEeeyZasfnNSonw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_0v7A1Y6dEeeyZasfnNSonw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0v7A2Y6dEeeyZasfnNSonw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0v7A1o6dEeeyZasfnNSonw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0v7A146dEeeyZasfnNSonw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0v7A2I6dEeeyZasfnNSonw"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_2ZXq4I6dEeeyZasfnNSonw" type="4001" source="_0s7-QY6dEeeyZasfnNSonw" target="_0s9Mbo6dEeeyZasfnNSonw">
       <children xmi:type="notation:DecorationNode" xmi:id="_2ZXq446dEeeyZasfnNSonw" type="6001">
@@ -903,16 +963,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2ZXq4o6dEeeyZasfnNSonw" points="[9, 19, -56, -109]$[11, 115, -54, -13]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2ar5gI6dEeeyZasfnNSonw" id="(0.9254807692307693,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2ar5gY6dEeeyZasfnNSonw" id="(0.31724137931034485,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_uGxtJ46eEeeyZasfnNSonw" type="StereotypeCommentLink" source="_2ZXq4I6dEeeyZasfnNSonw" target="_uGxtI46eEeeyZasfnNSonw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_uGxtKI6eEeeyZasfnNSonw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uGxtLI6eEeeyZasfnNSonw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_2YPCcI6dEeeyZasfnNSonw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uGxtKY6eEeeyZasfnNSonw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uGxtKo6eEeeyZasfnNSonw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uGxtK46eEeeyZasfnNSonw"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_rJyhtI8ZEeedErNofqJXiw" type="StereotypeCommentLink" source="_0slY8I6dEeeyZasfnNSonw" target="_rJyhsI8ZEeedErNofqJXiw">
       <styles xmi:type="notation:FontStyle" xmi:id="_rJyhtY8ZEeedErNofqJXiw"/>
@@ -994,15 +1044,88 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rPVwF48ZEeedErNofqJXiw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rPVwGI8ZEeedErNofqJXiw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_HMeSUM4xEeehIvzuBRCtZQ" type="StereotypeCommentLink" source="_0s_BkY6dEeeyZasfnNSonw" target="_HMdrQ84xEeehIvzuBRCtZQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_HMeSUc4xEeehIvzuBRCtZQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_HMeSVc4xEeehIvzuBRCtZQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_odv8VxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_0smADY6dEeeyZasfnNSonw" target="_odv8UxNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_odv8WBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_odv8XBNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_odv8WRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_odv8WhNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_odv8WxNqEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_pnWBpxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_0s_BkY6dEeeyZasfnNSonw" target="_pnWBoxNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_pnWBqBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pnWBrBNqEeiod932A6hg3A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_KjQ3phKOEeajhbtskMXJfw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HMeSUs4xEeehIvzuBRCtZQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HMeSU84xEeehIvzuBRCtZQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HMeSVM4xEeehIvzuBRCtZQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pnWBqRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pnWBqhNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pnWBqxNqEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_q2fVVxNqEeiod932A6hg3A" type="StereotypeCommentLink" source="_0s_BpY6dEeeyZasfnNSonw" target="_q2fVUxNqEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_q2fVWBNqEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_q2fVXBNqEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_KjQ3ohKOEeajhbtskMXJfw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_q2fVWRNqEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_q2fVWhNqEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_q2fVWxNqEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_D20w1xNsEeiod932A6hg3A" type="StereotypeCommentLink" source="_2ZXq4I6dEeeyZasfnNSonw" target="_D20w0xNsEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_D20w2BNsEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_D20w3BNsEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_2YPCcI6dEeeyZasfnNSonw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D20w2RNsEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D20w2hNsEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D20w2xNsEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ptZ7dxNsEeiod932A6hg3A" type="StereotypeCommentLink" source="_ptHnkBNsEeiod932A6hg3A" target="_ptZ7cxNsEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ptZ7eBNsEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ptZ7fBNsEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_k96BsIfbEeeirpBaj87qAw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ptZ7eRNsEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ptZ7ehNsEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ptZ7exNsEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yVOs4BNsEeiod932A6hg3A" type="StereotypeCommentLink" source="_yU8ZABNsEeiod932A6hg3A" target="_yVImUhNsEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yVOs4RNsEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_yVOs5RNsEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOtsi.uml#_YS8DkIfeEeet-8tHdGGp_w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yVOs4hNsEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yVOs4xNsEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yVOs5BNsEeiod932A6hg3A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_49BgQBNsEeiod932A6hg3A" type="4008" source="_yU8ZABNsEeiod932A6hg3A" target="_ptHnkBNsEeiod932A6hg3A">
+      <children xmi:type="notation:DecorationNode" xmi:id="_49Hm4BNsEeiod932A6hg3A" type="6026">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_49Hm4RNsEeiod932A6hg3A" x="11" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_49Hm4hNsEeiod932A6hg3A" type="6027">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_49Hm4xNsEeiod932A6hg3A" x="-10" y="-1"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_49BgQRNsEeiod932A6hg3A"/>
+      <element xmi:type="uml:Abstraction" href="TapiOtsi.uml#_7OKQUIfeEeet-8tHdGGp_w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_49BgQhNsEeiod932A6hg3A" points="[0, 0, -31, 148]$[31, -148, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_49Hm5BNsEeiod932A6hg3A" id="(0.501577287066246,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_49Hm5RNsEeiod932A6hg3A" id="(0.48582995951417,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_49mIBxNsEeiod932A6hg3A" type="StereotypeCommentLink" source="_49BgQBNsEeiod932A6hg3A" target="_49mIAxNsEeiod932A6hg3A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_49mICBNsEeiod932A6hg3A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_49mIDBNsEeiod932A6hg3A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOtsi.uml#_7OKQUIfeEeet-8tHdGGp_w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_49mICRNsEeiod932A6hg3A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_49mIChNsEeiod932A6hg3A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_49mICxNsEeiod932A6hg3A"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiOtsi.uml
+++ b/UML/TapiOtsi.uml
@@ -51,7 +51,7 @@ License: This module is distributed under the Apache License 2.0</body>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_UyBxsBKOEeajhbtskMXJfw" name="Diagrams"/>
     <packagedElement xmi:type="uml:Package" xmi:id="_bTHgIBKOEeajhbtskMXJfw" name="ObjectClasses">
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjQ3qhKOEeajhbtskMXJfw" name="OtsiAClientAdaptationPac"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjQ3qhKOEeajhbtskMXJfw" name="OtsiClientAdaptationPac"/>
       <packagedElement xmi:type="uml:Class" xmi:id="_KjQ3rRKOEeajhbtskMXJfw" name="OtsiConnectionEndPointSpec">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3rhKOEeajhbtskMXJfw" name="_otsiAdapter" type="_KjQ3qhKOEeajhbtskMXJfw" isReadOnly="true" aggregation="composite" association="_KjQ3ohKOEeajhbtskMXJfw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjQ3rxKOEeajhbtskMXJfw"/>
@@ -96,7 +96,7 @@ This attribute is required for the OCh Trial Termination Point Source at the tra
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Mf8-IM4xEeehIvzuBRCtZQ" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_PKMDsEUIEead1bezhJG4aw" name="OtsiAPoolPac">
+      <packagedElement xmi:type="uml:Class" xmi:id="_PKMDsEUIEead1bezhJG4aw" name="OtsiPoolPac">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_MpIOQI51EeeyZasfnNSonw" name="availableFrequencySlot" type="_ya6VcI6WEeeyZasfnNSonw" isReadOnly="true">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WlhUMI6cEeeyZasfnNSonw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WljwcI6cEeeyZasfnNSonw" value="*"/>
@@ -118,7 +118,7 @@ This attribute is required for the OCh Trial Termination Point Source at the tra
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_17F0MIfeEeet-8tHdGGp_w" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_nBhMkI6cEeeyZasfnNSonw" name="OtsiGCtpPac">
+      <packagedElement xmi:type="uml:Class" xmi:id="_nBhMkI6cEeeyZasfnNSonw" name="OtsiCtpPac">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_jVAoEJROEee0N_ppE1lIiw" name="selectedFrequencySlot" type="_ya6VcI6WEeeyZasfnNSonw" isReadOnly="true">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ojmz4JROEee0N_ppE1lIiw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ojs6gJROEee0N_ppE1lIiw" value="*"/>
@@ -303,8 +303,6 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:Experimental xmi:id="__ocTYBKOEeajhbtskMXJfw" base_Element="_KjQ3rhKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:Experimental xmi:id="_HKhtUBKmEeajhbtskMXJfw" base_Element="_KjQ3uxKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:Experimental xmi:id="_InurIBKmEeajhbtskMXJfw" base_Element="_KjQ3uRKOEeajhbtskMXJfw"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_ue4nIEUzEeaB8vMnkFQLXQ" base_Association="_KjQ3ohKOEeajhbtskMXJfw"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_st78AEU1EeaB8vMnkFQLXQ" base_Association="_hv9NsNnYEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ouzcsdK-Eeau-fGWj88_Vg" base_StructuralFeature="_hv9Ns9nYEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_wucSQBM0Eee0L_IMWjydgQ" base_StructuralFeature="_hv9NtdnYEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:Specify xmi:id="_lHWc4BNAEeeQQtMBY9ly8w" base_Abstraction="_Z6tlUBNAEeeQQtMBY9ly8w">
@@ -371,10 +369,12 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:OpenModelAttribute xmi:id="_2YQQko6dEeeyZasfnNSonw" base_StructuralFeature="_2YQQkI6dEeeyZasfnNSonw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2YQ3oY6dEeeyZasfnNSonw" base_Property="_2YQ3oI6dEeeyZasfnNSonw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_2YQ3oo6dEeeyZasfnNSonw" base_StructuralFeature="_2YQ3oI6dEeeyZasfnNSonw"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_uGqYYI6eEeeyZasfnNSonw" base_Association="_2YPCcI6dEeeyZasfnNSonw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_x9XaUZJmEee26o4qs2D5Ig" base_StructuralFeature="_x9XaUJJmEee26o4qs2D5Ig"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_x9YBYJJmEee26o4qs2D5Ig" base_Property="_x9XaUJJmEee26o4qs2D5Ig"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jXpsYJROEee0N_ppE1lIiw" base_Property="_jVAoEJROEee0N_ppE1lIiw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_jXrhkJROEee0N_ppE1lIiw" base_StructuralFeature="_jVAoEJROEee0N_ppE1lIiw"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_HMXkoM4xEeehIvzuBRCtZQ" base_Association="_KjQ3phKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_odjvEBNqEeiod932A6hg3A" base_Association="_hv9NsNnYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_pnP7ABNqEeiod932A6hg3A" base_Association="_KjQ3phKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_q2ZOsBNqEeiod932A6hg3A" base_Association="_KjQ3ohKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_sl9H0BNqEeiod932A6hg3A" base_Association="_2YPCcI6dEeeyZasfnNSonw"/>
 </xmi:XMI>

--- a/UML/TapiTopology.notation
+++ b/UML/TapiTopology.notation
@@ -419,41 +419,45 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_NPs5VjBDEea4fKwSGMr6CA" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_NPs5VzBDEea4fKwSGMr6CA" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_OEF2kNoHEeeYx-v40uoW_Q" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_DoMg8BNWEeiKtYjI8wVF7A" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_qpAjEKg3EeeAVfY3jqnvAA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEF2kdoHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DoMg8RNWEeiKtYjI8wVF7A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_OEF2ktoHEeeYx-v40uoW_Q" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_DoNIABNWEeiKtYjI8wVF7A" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_G1pfM9nfEeWIOYiRCk5bbQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEF2k9oHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DoNIARNWEeiKtYjI8wVF7A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_OEGdoNoHEeeYx-v40uoW_Q" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_DoNIAhNWEeiKtYjI8wVF7A" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_MM6iEEHBEeWqPKyD1j6LMg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEGdodoHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DoNIAxNWEeiKtYjI8wVF7A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_OEGdotoHEeeYx-v40uoW_Q" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_DoO9MBNWEeiKtYjI8wVF7A" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_STzYA-_tEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEGdo9oHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DoO9MRNWEeiKtYjI8wVF7A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_OEGdpNoHEeeYx-v40uoW_Q" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_DoPkQBNWEeiKtYjI8wVF7A" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_UbQckqg5EeeAVfY3jqnvAA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEGdpdoHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DoPkQRNWEeiKtYjI8wVF7A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_OEGdptoHEeeYx-v40uoW_Q" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_DoPkQhNWEeiKtYjI8wVF7A" type="3012">
+          <element xmi:type="uml:Property" href="TapiTopology.uml#_o-BkYRNVEeiKtYjI8wVF7A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DoPkQxNWEeiKtYjI8wVF7A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_DoQLUBNWEeiKtYjI8wVF7A" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_7vdVA2h_EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEGdp9oHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DoQLURNWEeiKtYjI8wVF7A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_OEGdqNoHEeeYx-v40uoW_Q" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_DoQLUhNWEeiKtYjI8wVF7A" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_7vdU-2h_EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEGdqdoHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DoQLUxNWEeiKtYjI8wVF7A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_OEHEsNoHEeeYx-v40uoW_Q" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_DoQLVBNWEeiKtYjI8wVF7A" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEHEsdoHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DoQLVRNWEeiKtYjI8wVF7A"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_OEHEstoHEeeYx-v40uoW_Q" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_DoQyYBNWEeiKtYjI8wVF7A" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEHEs9oHEeeYx-v40uoW_Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DoQyYRNWEeiKtYjI8wVF7A"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_NPs5_zBDEea4fKwSGMr6CA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_NPs6ADBDEea4fKwSGMr6CA"/>
@@ -511,7 +515,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NP2CtjBDEea4fKwSGMr6CA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NP2C5DBDEea4fKwSGMr6CA" x="524" y="69" height="93"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NP2C5DBDEea4fKwSGMr6CA" x="524" y="54" height="93"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_EpWpODBKEeaSroGqGbZ6jg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_EpWpOTBKEeaSroGqGbZ6jg" showTitle="true"/>
@@ -635,7 +639,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RnAzY6g5EeeAVfY3jqnvAA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RnAzUag5EeeAVfY3jqnvAA" x="526" y="206" height="87"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RnAzUag5EeeAVfY3jqnvAA" x="523" y="158" height="87"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_RnIIE6g5EeeAVfY3jqnvAA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_RnIIFKg5EeeAVfY3jqnvAA" showTitle="true"/>
@@ -717,6 +721,64 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GfPr0hKAEeix4OZk6OGmSg" x="726" y="106"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_-ikSoBNPEeiKtYjI8wVF7A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_-ikSoRNPEeiKtYjI8wVF7A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-ikSoxNPEeiKtYjI8wVF7A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_UbP1gKg5EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-ikSohNPEeiKtYjI8wVF7A" x="726" y="106"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gCWC0BNVEeiKtYjI8wVF7A" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_gCa7UBNVEeiKtYjI8wVF7A" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gCa7URNVEeiKtYjI8wVF7A" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gCa7UhNVEeiKtYjI8wVF7A" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_gCbiYBNVEeiKtYjI8wVF7A" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_hdJz8BNVEeiKtYjI8wVF7A" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_KjZXNdyKEeWXdJnxZxtFYA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_hdJz8RNVEeiKtYjI8wVF7A"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_hdKbABNVEeiKtYjI8wVF7A" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_KjZXOdyKEeWXdJnxZxtFYA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_hdKbARNVEeiKtYjI8wVF7A"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_gCbiYRNVEeiKtYjI8wVF7A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_gCbiYhNVEeiKtYjI8wVF7A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_gCbiYxNVEeiKtYjI8wVF7A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gCbiZBNVEeiKtYjI8wVF7A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_gCbiZRNVEeiKtYjI8wVF7A" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_gCbiZhNVEeiKtYjI8wVF7A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_gCbiZxNVEeiKtYjI8wVF7A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_gCbiaBNVEeiKtYjI8wVF7A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gCbiaRNVEeiKtYjI8wVF7A"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_gCbiahNVEeiKtYjI8wVF7A" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_gCbiaxNVEeiKtYjI8wVF7A"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_gCbibBNVEeiKtYjI8wVF7A"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_gCbibRNVEeiKtYjI8wVF7A"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gCbibhNVEeiKtYjI8wVF7A"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gCWC0RNVEeiKtYjI8wVF7A" x="523" y="256" height="86"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gCpk0xNVEeiKtYjI8wVF7A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_gCpk1BNVEeiKtYjI8wVF7A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gCpk1hNVEeiKtYjI8wVF7A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gCpk1RNVEeiKtYjI8wVF7A" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_2HAz4BNVEeiKtYjI8wVF7A" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_2HAz4RNVEeiKtYjI8wVF7A" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2HAz4xNVEeiKtYjI8wVF7A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_o-AWQBNVEeiKtYjI8wVF7A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2HAz4hNVEeiKtYjI8wVF7A" x="723" y="156"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_JS4dITBDEea4fKwSGMr6CA" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_JS4dIjBDEea4fKwSGMr6CA"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_JS4dIzBDEea4fKwSGMr6CA">
@@ -748,7 +810,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_NPs5EzBDEea4fKwSGMr6CA"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_STzYAO_tEeWLlrwIF3w0vA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NPs5GjBDEea4fKwSGMr6CA" points="[-10, 24, 28, -74]$[-46, 79, -8, -19]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NPs5GzBDEea4fKwSGMr6CA" id="(1.0,0.14563106796116504)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NPs5GzBDEea4fKwSGMr6CA" id="(1.0,0.06310679611650485)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NPs5HDBDEea4fKwSGMr6CA" id="(0.0,0.45161290322580644)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_EpWpPDBKEeaSroGqGbZ6jg" type="StereotypeCommentLink" source="_NPs5UzBDEea4fKwSGMr6CA" target="_EpWpODBKEeaSroGqGbZ6jg">
@@ -893,8 +955,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_Uco8oag5EeeAVfY3jqnvAA"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_UbP1gKg5EeeAVfY3jqnvAA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Uco8oqg5EeeAVfY3jqnvAA" points="[0, 0, 237, 72]$[-237, -9, 0, 63]$[-237, -72, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ud1PcKg5EeeAVfY3jqnvAA" id="(0.0,0.42528735632183906)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ud1Pcag5EeeAVfY3jqnvAA" id="(1.0,0.7766990291262136)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ud1PcKg5EeeAVfY3jqnvAA" id="(0.0,0.26436781609195403)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ud1Pcag5EeeAVfY3jqnvAA" id="(1.0,0.47572815533980584)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_iWsctKg5EeeAVfY3jqnvAA" type="StereotypeCommentLink" source="_Uco8oKg5EeeAVfY3jqnvAA">
       <styles xmi:type="notation:FontStyle" xmi:id="_iWsctag5EeeAVfY3jqnvAA"/>
@@ -995,6 +1057,61 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GfPr1hKAEeix4OZk6OGmSg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GfPr1xKAEeix4OZk6OGmSg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GfPr2BKAEeix4OZk6OGmSg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-ik5sBNPEeiKtYjI8wVF7A" type="StereotypeCommentLink" source="_Uco8oKg5EeeAVfY3jqnvAA" target="_-ikSoBNPEeiKtYjI8wVF7A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-ik5sRNPEeiKtYjI8wVF7A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-ilgwhNPEeiKtYjI8wVF7A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_UbP1gKg5EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-ik5shNPEeiKtYjI8wVF7A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-ilgwBNPEeiKtYjI8wVF7A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-ilgwRNPEeiKtYjI8wVF7A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_gCpk1xNVEeiKtYjI8wVF7A" type="StereotypeCommentLink" source="_gCWC0BNVEeiKtYjI8wVF7A" target="_gCpk0xNVEeiKtYjI8wVF7A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_gCpk2BNVEeiKtYjI8wVF7A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gCpk3BNVEeiKtYjI8wVF7A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gCpk2RNVEeiKtYjI8wVF7A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gCpk2hNVEeiKtYjI8wVF7A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gCpk2xNVEeiKtYjI8wVF7A"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_o_6awBNVEeiKtYjI8wVF7A" type="4001" source="_gCWC0BNVEeiKtYjI8wVF7A" target="_NPs5UzBDEea4fKwSGMr6CA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_o_6awxNVEeiKtYjI8wVF7A" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_o_6axBNVEeiKtYjI8wVF7A" x="1" y="-9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_o_6axRNVEeiKtYjI8wVF7A" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_o_6axhNVEeiKtYjI8wVF7A" x="2" y="10"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_o_6axxNVEeiKtYjI8wVF7A" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_o_7B0BNVEeiKtYjI8wVF7A" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_o_7B0RNVEeiKtYjI8wVF7A" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_o_7B0hNVEeiKtYjI8wVF7A" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_o_7B0xNVEeiKtYjI8wVF7A" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_o_7B1BNVEeiKtYjI8wVF7A" x="14" y="19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_o_7B1RNVEeiKtYjI8wVF7A" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_o_7B1hNVEeiKtYjI8wVF7A" x="-19" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_o_6awRNVEeiKtYjI8wVF7A"/>
+      <element xmi:type="uml:Association" href="TapiTopology.uml#_o-AWQBNVEeiKtYjI8wVF7A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_o_6awhNVEeiKtYjI8wVF7A" points="[15, 57, 5, 19]$[37, 57, 27, 19]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pBkAkBNVEeiKtYjI8wVF7A" id="(0.0,0.19767441860465115)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pBkAkRNVEeiKtYjI8wVF7A" id="(1.0,0.9223300970873787)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_2HAz5BNVEeiKtYjI8wVF7A" type="StereotypeCommentLink" source="_o_6awBNVEeiKtYjI8wVF7A" target="_2HAz4BNVEeiKtYjI8wVF7A">
+      <styles xmi:type="notation:FontStyle" xmi:id="_2HAz5RNVEeiKtYjI8wVF7A"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2HAz6RNVEeiKtYjI8wVF7A" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_o-AWQBNVEeiKtYjI8wVF7A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2HAz5hNVEeiKtYjI8wVF7A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2HAz5xNVEeiKtYjI8wVF7A"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2HAz6BNVEeiKtYjI8wVF7A"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_SFF5oDBDEea4fKwSGMr6CA" type="PapyrusUMLClassDiagram" name="TopologyServiceDetails" measurementUnit="Pixel">

--- a/UML/TapiTopology.uml
+++ b/UML/TapiTopology.uml
@@ -301,7 +301,14 @@ License: This module is distributed under the Apache License 2.0</body>
         <ownedEnd xmi:type="uml:Property" xmi:id="_UbRqsKg5EeeAVfY3jqnvAA" name="nodeedgepoint" type="_i1UzkD-3EeWNAdBR30aJhw" association="_UbP1gKg5EeeAVfY3jqnvAA"/>
       </packagedElement>
     </packagedElement>
-    <packagedElement xmi:type="uml:Package" xmi:id="_SXc0sC5xEea0_JngOlSKcA" name="Diagrams"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_SXc0sC5xEea0_JngOlSKcA" name="Diagrams">
+      <packagedElement xmi:type="uml:Association" xmi:id="_o-AWQBNVEeiKtYjI8wVF7A" name="NEPHasCapacityPac" memberEnd="_o-BkYRNVEeiKtYjI8wVF7A _o-CygBNVEeiKtYjI8wVF7A">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_o-A9UBNVEeiKtYjI8wVF7A" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_o-BkYBNVEeiKtYjI8wVF7A" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_o-CygBNVEeiKtYjI8wVF7A" name="nodeedgepoint" type="_i1UzkD-3EeWNAdBR30aJhw" association="_o-AWQBNVEeiKtYjI8wVF7A"/>
+      </packagedElement>
+    </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_QOoHAC5xEea0_JngOlSKcA" name="Imports">
       <packageImport xmi:type="uml:PackageImport" xmi:id="_LArf4DA8Eea4fKwSGMr6CA">
         <importedPackage xmi:type="uml:Model" href="TapiCommon.uml#_cOw5UDA4Eea4fKwSGMr6CA"/>
@@ -523,7 +530,7 @@ The structure of LTP supports all transport protocols including circuit and pack
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_UMztkNnfEeWIOYiRCk5bbQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_UMztkdnfEeWIOYiRCk5bbQ" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_MM6iEEHBEeWqPKyD1j6LMg" name="_mappedServiceInterfacePoint" association="_MM4s4EHBEeWqPKyD1j6LMg">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_MM6iEEHBEeWqPKyD1j6LMg" name="_mappedServiceInterfacePoint" isReadOnly="true" association="_MM4s4EHBEeWqPKyD1j6LMg">
           <ownedComment xmi:type="uml:Comment" xmi:id="_pWHaEEq8EeexQa2RWFy3AQ" annotatedElement="_MM6iEEHBEeWqPKyD1j6LMg">
             <body>NodeEdgePoint mapped to more than ServiceInterfacePoint (slicing/virtualizing) or a ServiceInterfacePoint mapped to more than one NodeEdgePoint (load balancing/Resilience) should be considered experimental</body>
           </ownedComment>
@@ -536,6 +543,9 @@ The structure of LTP supports all transport protocols including circuit and pack
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_UbQckqg5EeeAVfY3jqnvAA" name="_termination" isReadOnly="true" aggregation="composite" association="_UbP1gKg5EeeAVfY3jqnvAA">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_o-BkYRNVEeiKtYjI8wVF7A" name="_capacity" isReadOnly="true" aggregation="composite" association="_o-AWQBNVEeiKtYjI8wVF7A">
+          <type xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_7vdVA2h_EeWZEqTYAF8eqA" name="linkPortDirection" visibility="public" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_7vdVBGh_EeWZEqTYAF8eqA" annotatedElement="_7vdVA2h_EeWZEqTYAF8eqA">
@@ -1312,4 +1322,9 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenModel_Profile:OpenModelAttribute xmi:id="_UbRqsag5EeeAVfY3jqnvAA" base_StructuralFeature="_UbRqsKg5EeeAVfY3jqnvAA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_UbRqsqg5EeeAVfY3jqnvAA" base_Property="_UbRqsKg5EeeAVfY3jqnvAA"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_iWm9IKg5EeeAVfY3jqnvAA" base_Association="_UbP1gKg5EeeAVfY3jqnvAA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_o-BkYhNVEeiKtYjI8wVF7A" base_StructuralFeature="_o-BkYRNVEeiKtYjI8wVF7A"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_o-CLcBNVEeiKtYjI8wVF7A" base_Property="_o-BkYRNVEeiKtYjI8wVF7A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_o-DZkBNVEeiKtYjI8wVF7A" base_StructuralFeature="_o-CygBNVEeiKtYjI8wVF7A"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_o-DZkRNVEeiKtYjI8wVF7A" base_Property="_o-CygBNVEeiKtYjI8wVF7A"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_2G1NsBNVEeiKtYjI8wVF7A" base_Association="_o-AWQBNVEeiKtYjI8wVF7A"/>
 </xmi:XMI>

--- a/YANG/tapi-common.yang
+++ b/YANG/tapi-common.yang
@@ -246,6 +246,9 @@ module tapi-common {
                 enum ETY {
                     description "Models the ETY layer as per ITU-T G.8010";
                 }
+                enum DSR {
+                    description "Models a Digital Signal of an unspecified rate. This value can be used when the intent is to respresent an generic digital layer signal without making any statement on its format or overhead (processing) capabilities.";
+                }
             }
             description "Provides a controlled list of layer protocol names and indicates the naming authority.
                 Note that it is expected that attributes will be added to this structure to convey the naming authority name, the name of the layer protocol using a human readable string and any particular standard reference.

--- a/YANG/tapi-common.yang
+++ b/YANG/tapi-common.yang
@@ -90,11 +90,11 @@ module tapi-common {
             description "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.";
         }
         container context {
-        	presence "TAPI";
-            uses context;
+            uses tapi-context;
+            presence "Root container for all TAPI interaction";
             description "none";
         }
-        grouping context {
+        grouping tapi-context {
             list service-interface-point {
                 key 'uuid';
                 min-elements 2;

--- a/YANG/tapi-connectivity.tree
+++ b/YANG/tapi-connectivity.tree
@@ -5,46 +5,25 @@ module: tapi-connectivity
     |  |  +--rw layer-protocol-name?       tapi-common:layer-protocol-name
     |  |  +--rw service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |  |  +--rw capacity
-    |  |  |  +--ro total-potential-capacity
-    |  |  |  |  +--ro total-size
-    |  |  |  |  |  +--ro value?   uint64
-    |  |  |  |  |  +--ro unit?    capacity-unit
-    |  |  |  |  +--ro bandwidth-profile
-    |  |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-    |  |  |  |     +--ro committed-information-rate
-    |  |  |  |     |  +--ro value?   uint64
-    |  |  |  |     |  +--ro unit?    capacity-unit
-    |  |  |  |     +--ro committed-burst-size
-    |  |  |  |     |  +--ro value?   uint64
-    |  |  |  |     |  +--ro unit?    capacity-unit
-    |  |  |  |     +--ro peak-information-rate
-    |  |  |  |     |  +--ro value?   uint64
-    |  |  |  |     |  +--ro unit?    capacity-unit
-    |  |  |  |     +--ro peak-burst-size
-    |  |  |  |     |  +--ro value?   uint64
-    |  |  |  |     |  +--ro unit?    capacity-unit
-    |  |  |  |     +--ro color-aware?                  boolean
-    |  |  |  |     +--ro coupling-flag?                boolean
-    |  |  |  +--ro available-capacity
-    |  |  |     +--ro total-size
-    |  |  |     |  +--ro value?   uint64
-    |  |  |     |  +--ro unit?    capacity-unit
-    |  |  |     +--ro bandwidth-profile
-    |  |  |        +--ro bw-profile-type?              bandwidth-profile-type
-    |  |  |        +--ro committed-information-rate
-    |  |  |        |  +--ro value?   uint64
-    |  |  |        |  +--ro unit?    capacity-unit
-    |  |  |        +--ro committed-burst-size
-    |  |  |        |  +--ro value?   uint64
-    |  |  |        |  +--ro unit?    capacity-unit
-    |  |  |        +--ro peak-information-rate
-    |  |  |        |  +--ro value?   uint64
-    |  |  |        |  +--ro unit?    capacity-unit
-    |  |  |        +--ro peak-burst-size
-    |  |  |        |  +--ro value?   uint64
-    |  |  |        |  +--ro unit?    capacity-unit
-    |  |  |        +--ro color-aware?                  boolean
-    |  |  |        +--ro coupling-flag?                boolean
+    |  |  |  +--rw total-size
+    |  |  |  |  +--rw value?   uint64
+    |  |  |  |  +--rw unit?    capacity-unit
+    |  |  |  +--rw bandwidth-profile
+    |  |  |     +--rw bw-profile-type?              bandwidth-profile-type
+    |  |  |     +--rw committed-information-rate
+    |  |  |     |  +--rw value?   uint64
+    |  |  |     |  +--rw unit?    capacity-unit
+    |  |  |     +--rw committed-burst-size
+    |  |  |     |  +--rw value?   uint64
+    |  |  |     |  +--rw unit?    capacity-unit
+    |  |  |     +--rw peak-information-rate
+    |  |  |     |  +--rw value?   uint64
+    |  |  |     |  +--rw unit?    capacity-unit
+    |  |  |     +--rw peak-burst-size
+    |  |  |     |  +--rw value?   uint64
+    |  |  |     |  +--rw unit?    capacity-unit
+    |  |  |     +--rw color-aware?                  boolean
+    |  |  |     +--rw coupling-flag?                boolean
     |  |  +--rw direction?                 tapi-common:port-direction
     |  |  +--rw role?                      tapi-common:port-role
     |  |  +--rw protection-role?           protection-role
@@ -62,44 +41,44 @@ module: tapi-connectivity
     |  +--rw name* [value-name]
     |  |  +--rw value-name    string
     |  |  +--rw value?        string
-    |  +--ro service-type?                         service-type
-    |  +--ro service-level?                        string
+    |  +--rw service-type?                         service-type
+    |  +--rw service-level?                        string
     |  +--rw is-exclusive?                         boolean
-    |  +--ro requested-capacity
-    |  |  +--ro total-size
-    |  |  |  +--ro value?   uint64
-    |  |  |  +--ro unit?    capacity-unit
-    |  |  +--ro bandwidth-profile
-    |  |     +--ro bw-profile-type?              bandwidth-profile-type
-    |  |     +--ro committed-information-rate
-    |  |     |  +--ro value?   uint64
-    |  |     |  +--ro unit?    capacity-unit
-    |  |     +--ro committed-burst-size
-    |  |     |  +--ro value?   uint64
-    |  |     |  +--ro unit?    capacity-unit
-    |  |     +--ro peak-information-rate
-    |  |     |  +--ro value?   uint64
-    |  |     |  +--ro unit?    capacity-unit
-    |  |     +--ro peak-burst-size
-    |  |     |  +--ro value?   uint64
-    |  |     |  +--ro unit?    capacity-unit
-    |  |     +--ro color-aware?                  boolean
-    |  |     +--ro coupling-flag?                boolean
+    |  +--rw requested-capacity
+    |  |  +--rw total-size
+    |  |  |  +--rw value?   uint64
+    |  |  |  +--rw unit?    capacity-unit
+    |  |  +--rw bandwidth-profile
+    |  |     +--rw bw-profile-type?              bandwidth-profile-type
+    |  |     +--rw committed-information-rate
+    |  |     |  +--rw value?   uint64
+    |  |     |  +--rw unit?    capacity-unit
+    |  |     +--rw committed-burst-size
+    |  |     |  +--rw value?   uint64
+    |  |     |  +--rw unit?    capacity-unit
+    |  |     +--rw peak-information-rate
+    |  |     |  +--rw value?   uint64
+    |  |     |  +--rw unit?    capacity-unit
+    |  |     +--rw peak-burst-size
+    |  |     |  +--rw value?   uint64
+    |  |     |  +--rw unit?    capacity-unit
+    |  |     +--rw color-aware?                  boolean
+    |  |     +--rw coupling-flag?                boolean
     |  +--rw schedule
     |  |  +--rw end-time?     date-and-time
     |  |  +--rw start-time?   date-and-time
-    |  +--ro cost-characteristic* [cost-name]
-    |  |  +--ro cost-name         string
-    |  |  +--ro cost-value?       string
-    |  |  +--ro cost-algorithm?   string
-    |  +--ro latency-characteristic* [traffic-property-name]
-    |  |  +--ro traffic-property-name            string
+    |  +--rw cost-characteristic* [cost-name]
+    |  |  +--rw cost-name         string
+    |  |  +--rw cost-value?       string
+    |  |  +--rw cost-algorithm?   string
+    |  +--rw latency-characteristic* [traffic-property-name]
+    |  |  +--rw traffic-property-name            string
     |  |  +--ro fixed-latency-characteristic?    string
-    |  |  +--ro queing-latency-characteristic?   string
+    |  |  +--rw queing-latency-characteristic?   string
     |  |  +--ro jitter-characteristic?           string
     |  |  +--ro wander-characteristic?           string
-    |  +--ro coroute-inclusion?                    -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  +--ro diversity-exclusion*                  -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |  +--rw coroute-inclusion?                    -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |  +--rw diversity-exclusion*                  -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
     |  +--rw route-objective-function?             route-objective-function
     |  +--rw diversity-policy?                     diversity-policy
     |  +--ro include-topology*                     -> /tapi-common:context/tapi-topology:topology/uuid
@@ -249,46 +228,25 @@ module: tapi-connectivity
     |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
     |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro capacity
-    |        |  |  +--ro total-potential-capacity
-    |        |  |  |  +--ro total-size
-    |        |  |  |  |  +--ro value?   uint64
-    |        |  |  |  |  +--ro unit?    capacity-unit
-    |        |  |  |  +--ro bandwidth-profile
-    |        |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |  |     +--ro committed-information-rate
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro committed-burst-size
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro peak-information-rate
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro peak-burst-size
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro color-aware?                  boolean
-    |        |  |  |     +--ro coupling-flag?                boolean
-    |        |  |  +--ro available-capacity
-    |        |  |     +--ro total-size
+    |        |  |  +--ro total-size
+    |        |  |  |  +--ro value?   uint64
+    |        |  |  |  +--ro unit?    capacity-unit
+    |        |  |  +--ro bandwidth-profile
+    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate
     |        |  |     |  +--ro value?   uint64
     |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro bandwidth-profile
-    |        |  |        +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |        +--ro committed-information-rate
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro committed-burst-size
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro peak-information-rate
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro peak-burst-size
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro color-aware?                  boolean
-    |        |  |        +--ro coupling-flag?                boolean
+    |        |  |     +--ro committed-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-information-rate
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
     |        |  +--ro direction?                 tapi-common:port-direction
     |        |  +--ro role?                      tapi-common:port-role
     |        |  +--ro protection-role?           protection-role
@@ -380,46 +338,25 @@ module: tapi-connectivity
     |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
     |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro capacity
-    |        |  |  +--ro total-potential-capacity
-    |        |  |  |  +--ro total-size
-    |        |  |  |  |  +--ro value?   uint64
-    |        |  |  |  |  +--ro unit?    capacity-unit
-    |        |  |  |  +--ro bandwidth-profile
-    |        |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |  |     +--ro committed-information-rate
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro committed-burst-size
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro peak-information-rate
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro peak-burst-size
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro color-aware?                  boolean
-    |        |  |  |     +--ro coupling-flag?                boolean
-    |        |  |  +--ro available-capacity
-    |        |  |     +--ro total-size
+    |        |  |  +--ro total-size
+    |        |  |  |  +--ro value?   uint64
+    |        |  |  |  +--ro unit?    capacity-unit
+    |        |  |  +--ro bandwidth-profile
+    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate
     |        |  |     |  +--ro value?   uint64
     |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro bandwidth-profile
-    |        |  |        +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |        +--ro committed-information-rate
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro committed-burst-size
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro peak-information-rate
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro peak-burst-size
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro color-aware?                  boolean
-    |        |  |        +--ro coupling-flag?                boolean
+    |        |  |     +--ro committed-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-information-rate
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
     |        |  +--ro direction?                 tapi-common:port-direction
     |        |  +--ro role?                      tapi-common:port-role
     |        |  +--ro protection-role?           protection-role
@@ -508,46 +445,25 @@ module: tapi-connectivity
     |  |  |  +---w layer-protocol-name?       tapi-common:layer-protocol-name
     |  |  |  +---w service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |  |  |  +---w capacity
-    |  |  |  |  +---w total-potential-capacity
-    |  |  |  |  |  +---w total-size
-    |  |  |  |  |  |  +---w value?   uint64
-    |  |  |  |  |  |  +---w unit?    capacity-unit
-    |  |  |  |  |  +---w bandwidth-profile
-    |  |  |  |  |     +---w bw-profile-type?              bandwidth-profile-type
-    |  |  |  |  |     +---w committed-information-rate
-    |  |  |  |  |     |  +---w value?   uint64
-    |  |  |  |  |     |  +---w unit?    capacity-unit
-    |  |  |  |  |     +---w committed-burst-size
-    |  |  |  |  |     |  +---w value?   uint64
-    |  |  |  |  |     |  +---w unit?    capacity-unit
-    |  |  |  |  |     +---w peak-information-rate
-    |  |  |  |  |     |  +---w value?   uint64
-    |  |  |  |  |     |  +---w unit?    capacity-unit
-    |  |  |  |  |     +---w peak-burst-size
-    |  |  |  |  |     |  +---w value?   uint64
-    |  |  |  |  |     |  +---w unit?    capacity-unit
-    |  |  |  |  |     +---w color-aware?                  boolean
-    |  |  |  |  |     +---w coupling-flag?                boolean
-    |  |  |  |  +---w available-capacity
-    |  |  |  |     +---w total-size
+    |  |  |  |  +---w total-size
+    |  |  |  |  |  +---w value?   uint64
+    |  |  |  |  |  +---w unit?    capacity-unit
+    |  |  |  |  +---w bandwidth-profile
+    |  |  |  |     +---w bw-profile-type?              bandwidth-profile-type
+    |  |  |  |     +---w committed-information-rate
     |  |  |  |     |  +---w value?   uint64
     |  |  |  |     |  +---w unit?    capacity-unit
-    |  |  |  |     +---w bandwidth-profile
-    |  |  |  |        +---w bw-profile-type?              bandwidth-profile-type
-    |  |  |  |        +---w committed-information-rate
-    |  |  |  |        |  +---w value?   uint64
-    |  |  |  |        |  +---w unit?    capacity-unit
-    |  |  |  |        +---w committed-burst-size
-    |  |  |  |        |  +---w value?   uint64
-    |  |  |  |        |  +---w unit?    capacity-unit
-    |  |  |  |        +---w peak-information-rate
-    |  |  |  |        |  +---w value?   uint64
-    |  |  |  |        |  +---w unit?    capacity-unit
-    |  |  |  |        +---w peak-burst-size
-    |  |  |  |        |  +---w value?   uint64
-    |  |  |  |        |  +---w unit?    capacity-unit
-    |  |  |  |        +---w color-aware?                  boolean
-    |  |  |  |        +---w coupling-flag?                boolean
+    |  |  |  |     +---w committed-burst-size
+    |  |  |  |     |  +---w value?   uint64
+    |  |  |  |     |  +---w unit?    capacity-unit
+    |  |  |  |     +---w peak-information-rate
+    |  |  |  |     |  +---w value?   uint64
+    |  |  |  |     |  +---w unit?    capacity-unit
+    |  |  |  |     +---w peak-burst-size
+    |  |  |  |     |  +---w value?   uint64
+    |  |  |  |     |  +---w unit?    capacity-unit
+    |  |  |  |     +---w color-aware?                  boolean
+    |  |  |  |     +---w coupling-flag?                boolean
     |  |  |  +---w direction?                 tapi-common:port-direction
     |  |  |  +---w role?                      tapi-common:port-role
     |  |  |  +---w protection-role?           protection-role
@@ -630,46 +546,25 @@ module: tapi-connectivity
     |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
     |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro capacity
-    |        |  |  +--ro total-potential-capacity
-    |        |  |  |  +--ro total-size
-    |        |  |  |  |  +--ro value?   uint64
-    |        |  |  |  |  +--ro unit?    capacity-unit
-    |        |  |  |  +--ro bandwidth-profile
-    |        |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |  |     +--ro committed-information-rate
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro committed-burst-size
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro peak-information-rate
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro peak-burst-size
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro color-aware?                  boolean
-    |        |  |  |     +--ro coupling-flag?                boolean
-    |        |  |  +--ro available-capacity
-    |        |  |     +--ro total-size
+    |        |  |  +--ro total-size
+    |        |  |  |  +--ro value?   uint64
+    |        |  |  |  +--ro unit?    capacity-unit
+    |        |  |  +--ro bandwidth-profile
+    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate
     |        |  |     |  +--ro value?   uint64
     |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro bandwidth-profile
-    |        |  |        +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |        +--ro committed-information-rate
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro committed-burst-size
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro peak-information-rate
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro peak-burst-size
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro color-aware?                  boolean
-    |        |  |        +--ro coupling-flag?                boolean
+    |        |  |     +--ro committed-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-information-rate
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
     |        |  +--ro direction?                 tapi-common:port-direction
     |        |  +--ro role?                      tapi-common:port-role
     |        |  +--ro protection-role?           protection-role
@@ -759,46 +654,25 @@ module: tapi-connectivity
     |  |  |  +---w layer-protocol-name?       tapi-common:layer-protocol-name
     |  |  |  +---w service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |  |  |  +---w capacity
-    |  |  |  |  +---w total-potential-capacity
-    |  |  |  |  |  +---w total-size
-    |  |  |  |  |  |  +---w value?   uint64
-    |  |  |  |  |  |  +---w unit?    capacity-unit
-    |  |  |  |  |  +---w bandwidth-profile
-    |  |  |  |  |     +---w bw-profile-type?              bandwidth-profile-type
-    |  |  |  |  |     +---w committed-information-rate
-    |  |  |  |  |     |  +---w value?   uint64
-    |  |  |  |  |     |  +---w unit?    capacity-unit
-    |  |  |  |  |     +---w committed-burst-size
-    |  |  |  |  |     |  +---w value?   uint64
-    |  |  |  |  |     |  +---w unit?    capacity-unit
-    |  |  |  |  |     +---w peak-information-rate
-    |  |  |  |  |     |  +---w value?   uint64
-    |  |  |  |  |     |  +---w unit?    capacity-unit
-    |  |  |  |  |     +---w peak-burst-size
-    |  |  |  |  |     |  +---w value?   uint64
-    |  |  |  |  |     |  +---w unit?    capacity-unit
-    |  |  |  |  |     +---w color-aware?                  boolean
-    |  |  |  |  |     +---w coupling-flag?                boolean
-    |  |  |  |  +---w available-capacity
-    |  |  |  |     +---w total-size
+    |  |  |  |  +---w total-size
+    |  |  |  |  |  +---w value?   uint64
+    |  |  |  |  |  +---w unit?    capacity-unit
+    |  |  |  |  +---w bandwidth-profile
+    |  |  |  |     +---w bw-profile-type?              bandwidth-profile-type
+    |  |  |  |     +---w committed-information-rate
     |  |  |  |     |  +---w value?   uint64
     |  |  |  |     |  +---w unit?    capacity-unit
-    |  |  |  |     +---w bandwidth-profile
-    |  |  |  |        +---w bw-profile-type?              bandwidth-profile-type
-    |  |  |  |        +---w committed-information-rate
-    |  |  |  |        |  +---w value?   uint64
-    |  |  |  |        |  +---w unit?    capacity-unit
-    |  |  |  |        +---w committed-burst-size
-    |  |  |  |        |  +---w value?   uint64
-    |  |  |  |        |  +---w unit?    capacity-unit
-    |  |  |  |        +---w peak-information-rate
-    |  |  |  |        |  +---w value?   uint64
-    |  |  |  |        |  +---w unit?    capacity-unit
-    |  |  |  |        +---w peak-burst-size
-    |  |  |  |        |  +---w value?   uint64
-    |  |  |  |        |  +---w unit?    capacity-unit
-    |  |  |  |        +---w color-aware?                  boolean
-    |  |  |  |        +---w coupling-flag?                boolean
+    |  |  |  |     +---w committed-burst-size
+    |  |  |  |     |  +---w value?   uint64
+    |  |  |  |     |  +---w unit?    capacity-unit
+    |  |  |  |     +---w peak-information-rate
+    |  |  |  |     |  +---w value?   uint64
+    |  |  |  |     |  +---w unit?    capacity-unit
+    |  |  |  |     +---w peak-burst-size
+    |  |  |  |     |  +---w value?   uint64
+    |  |  |  |     |  +---w unit?    capacity-unit
+    |  |  |  |     +---w color-aware?                  boolean
+    |  |  |  |     +---w coupling-flag?                boolean
     |  |  |  +---w direction?                 tapi-common:port-direction
     |  |  |  +---w role?                      tapi-common:port-role
     |  |  |  +---w protection-role?           protection-role
@@ -881,46 +755,25 @@ module: tapi-connectivity
     |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
     |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro capacity
-    |        |  |  +--ro total-potential-capacity
-    |        |  |  |  +--ro total-size
-    |        |  |  |  |  +--ro value?   uint64
-    |        |  |  |  |  +--ro unit?    capacity-unit
-    |        |  |  |  +--ro bandwidth-profile
-    |        |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |  |     +--ro committed-information-rate
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro committed-burst-size
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro peak-information-rate
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro peak-burst-size
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro color-aware?                  boolean
-    |        |  |  |     +--ro coupling-flag?                boolean
-    |        |  |  +--ro available-capacity
-    |        |  |     +--ro total-size
+    |        |  |  +--ro total-size
+    |        |  |  |  +--ro value?   uint64
+    |        |  |  |  +--ro unit?    capacity-unit
+    |        |  |  +--ro bandwidth-profile
+    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate
     |        |  |     |  +--ro value?   uint64
     |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro bandwidth-profile
-    |        |  |        +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |        +--ro committed-information-rate
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro committed-burst-size
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro peak-information-rate
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro peak-burst-size
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro color-aware?                  boolean
-    |        |  |        +--ro coupling-flag?                boolean
+    |        |  |     +--ro committed-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-information-rate
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
     |        |  +--ro direction?                 tapi-common:port-direction
     |        |  +--ro role?                      tapi-common:port-role
     |        |  +--ro protection-role?           protection-role
@@ -1012,46 +865,25 @@ module: tapi-connectivity
              |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
              |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
              |  +--ro capacity
-             |  |  +--ro total-potential-capacity
-             |  |  |  +--ro total-size
-             |  |  |  |  +--ro value?   uint64
-             |  |  |  |  +--ro unit?    capacity-unit
-             |  |  |  +--ro bandwidth-profile
-             |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-             |  |  |     +--ro committed-information-rate
-             |  |  |     |  +--ro value?   uint64
-             |  |  |     |  +--ro unit?    capacity-unit
-             |  |  |     +--ro committed-burst-size
-             |  |  |     |  +--ro value?   uint64
-             |  |  |     |  +--ro unit?    capacity-unit
-             |  |  |     +--ro peak-information-rate
-             |  |  |     |  +--ro value?   uint64
-             |  |  |     |  +--ro unit?    capacity-unit
-             |  |  |     +--ro peak-burst-size
-             |  |  |     |  +--ro value?   uint64
-             |  |  |     |  +--ro unit?    capacity-unit
-             |  |  |     +--ro color-aware?                  boolean
-             |  |  |     +--ro coupling-flag?                boolean
-             |  |  +--ro available-capacity
-             |  |     +--ro total-size
+             |  |  +--ro total-size
+             |  |  |  +--ro value?   uint64
+             |  |  |  +--ro unit?    capacity-unit
+             |  |  +--ro bandwidth-profile
+             |  |     +--ro bw-profile-type?              bandwidth-profile-type
+             |  |     +--ro committed-information-rate
              |  |     |  +--ro value?   uint64
              |  |     |  +--ro unit?    capacity-unit
-             |  |     +--ro bandwidth-profile
-             |  |        +--ro bw-profile-type?              bandwidth-profile-type
-             |  |        +--ro committed-information-rate
-             |  |        |  +--ro value?   uint64
-             |  |        |  +--ro unit?    capacity-unit
-             |  |        +--ro committed-burst-size
-             |  |        |  +--ro value?   uint64
-             |  |        |  +--ro unit?    capacity-unit
-             |  |        +--ro peak-information-rate
-             |  |        |  +--ro value?   uint64
-             |  |        |  +--ro unit?    capacity-unit
-             |  |        +--ro peak-burst-size
-             |  |        |  +--ro value?   uint64
-             |  |        |  +--ro unit?    capacity-unit
-             |  |        +--ro color-aware?                  boolean
-             |  |        +--ro coupling-flag?                boolean
+             |  |     +--ro committed-burst-size
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro peak-information-rate
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro peak-burst-size
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro color-aware?                  boolean
+             |  |     +--ro coupling-flag?                boolean
              |  +--ro direction?                 tapi-common:port-direction
              |  +--ro role?                      tapi-common:port-role
              |  +--ro protection-role?           protection-role

--- a/YANG/tapi-connectivity.tree
+++ b/YANG/tapi-connectivity.tree
@@ -115,8 +115,8 @@ module: tapi-connectivity
        |  +--ro name* [value-name]
        |     +--ro value-name    string
        |     +--ro value?        string
-       +--ro switch-control* [local-id]
-       |  +--ro sub-switch-control*                   -> /tapi-common:context/tapi-connectivity:connection/switch-control/local-id
+       +--ro switch-control* [uuid]
+       |  +--ro sub-switch-control*                   -> /tapi-common:context/tapi-connectivity:connection/switch-control/uuid
        |  +--ro switch* [local-id]
        |  |  +--ro selected-connection-end-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
        |  |  +--ro selected-route*                  -> /tapi-common:context/tapi-connectivity:connection/route/local-id
@@ -127,7 +127,7 @@ module: tapi-connectivity
        |  |  +--ro name* [value-name]
        |  |     +--ro value-name    string
        |  |     +--ro value?        string
-       |  +--ro local-id                              string
+       |  +--ro uuid                                  uuid
        |  +--ro name* [value-name]
        |  |  +--ro value-name    string
        |  |  +--ro value?        string
@@ -184,8 +184,8 @@ module: tapi-connectivity
     |        |  +--ro name* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
-    |        +--ro switch-control* [local-id]
-    |        |  +--ro sub-switch-control*                   -> /tapi-common:context/tapi-connectivity:connection/switch-control/local-id
+    |        +--ro switch-control* [uuid]
+    |        |  +--ro sub-switch-control*                   -> /tapi-common:context/tapi-connectivity:connection/switch-control/uuid
     |        |  +--ro switch* [local-id]
     |        |  |  +--ro selected-connection-end-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |        |  |  +--ro selected-route*                  -> /tapi-common:context/tapi-connectivity:connection/route/local-id
@@ -196,7 +196,7 @@ module: tapi-connectivity
     |        |  |  +--ro name* [value-name]
     |        |  |     +--ro value-name    string
     |        |  |     +--ro value?        string
-    |        |  +--ro local-id                              string
+    |        |  +--ro uuid                                  uuid
     |        |  +--ro name* [value-name]
     |        |  |  +--ro value-name    string
     |        |  |  +--ro value?        string

--- a/YANG/tapi-connectivity.yang
+++ b/YANG/tapi-connectivity.yang
@@ -131,12 +131,10 @@ module tapi-connectivity {
         grouping connectivity-constraint {
             leaf service-type {
                 type service-type;
-                config false;
                 description "none";
             }
             leaf service-level {
                 type string;
-                config false;
                 description "An abstract value the meaning of which is mutually agreed – typically represents metrics such as - Class of service, priority, resiliency, availability";
             }
             leaf is-exclusive {
@@ -145,7 +143,6 @@ module tapi-connectivity {
                 description "To distinguish if the resources are exclusive to the service  - for example between EPL(isExclusive=true) and EVPL (isExclusive=false), or between EPLAN (isExclusive=true) and EVPLAN (isExclusive=false)";
             }
             container requested-capacity {
-                config false;
                 uses tapi-common:capacity;
                 description "none";
             }
@@ -155,13 +152,11 @@ module tapi-connectivity {
             }
             list cost-characteristic {
                 key 'cost-name';
-                config false;
                 uses tapi-topology:cost-characteristic;
                 description "The list of costs where each cost relates to some aspect of the TopologicalEntity.";
             }
             list latency-characteristic {
                 key 'traffic-property-name';
-                config false;
                 uses tapi-topology:latency-characteristic;
                 description "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.";
             }
@@ -169,14 +164,12 @@ module tapi-connectivity {
                 type leafref {
                     path '/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid';
                 }
-                config false;
                 description "none";
             }
             leaf-list diversity-exclusion {
                 type leafref {
                     path '/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid';
                 }
-                config false;
                 description "none";
             }
             uses route-compute-policy;
@@ -224,7 +217,7 @@ module tapi-connectivity {
                 description "none";
             }
             container capacity {
-                uses tapi-common:capacity-pac;
+                uses tapi-common:capacity;
                 description "none";
             }
             leaf direction {

--- a/YANG/tapi-connectivity.yang
+++ b/YANG/tapi-connectivity.yang
@@ -65,7 +65,7 @@ module tapi-connectivity {
                 description "none";
             }
             list switch-control {
-                key 'local-id';
+                key 'uuid';
                 config false;
                 uses switch-control;
                 description "none";
@@ -315,7 +315,7 @@ module tapi-connectivity {
         grouping switch-control {
             leaf-list sub-switch-control {
                 type leafref {
-                    path '/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:local-id';
+                    path '/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:uuid';
                 }
                 description "none";
             }
@@ -324,7 +324,7 @@ module tapi-connectivity {
                 uses switch;
                 description "none";
             }
-            uses tapi-common:local-class;
+            uses tapi-common:resource-spec;
             uses resilience-constraint;
             description "Represents the capability to control and coordinate switches, to add/delete/modify FCs and to add/delete/modify LTPs/LPs so as to realize a protection scheme.";
         }

--- a/YANG/tapi-eth.tree
+++ b/YANG/tapi-eth.tree
@@ -1,93 +1,98 @@
 module: tapi-eth
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
-    +--ro is-fts-enabled?        boolean
-    +--ro is-tx-pause-enabled?   boolean
-    +--ro phy-type?              ety-phy-type
-    +--ro phy-type-list*         ety-phy-type
+    +--ro ety-term
+       +--ro is-fts-enabled?        boolean
+       +--ro is-tx-pause-enabled?   boolean
+       +--ro phy-type?              ety-phy-type
+       +--ro phy-type-list*         ety-phy-type
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
-    +--ro priority-regenerate
-    |  +--ro priority-0?   uint64
-    |  +--ro priority-1?   uint64
-    |  +--ro priority-2?   uint64
-    |  +--ro priority-3?   uint64
-    |  +--ro priority-4?   uint64
-    |  +--ro priority-5?   uint64
-    |  +--ro priority-6?   uint64
-    |  +--ro priority-7?   uint64
-    +--ro ether-type?                             vlan-type
-    +--ro filter-config-1*                        mac-address
-    +--ro frametype-config?                       frame-type
-    +--ro port-vid?                               vid
-    +--ro priority-code-point-config?             pcp-coding
-    +--ro auxiliary-function-position-sequence*   uint64
-    +--ro vlan-config?                            uint64
-    +--ro csf-rdi-fdi-enable?                     boolean
-    +--ro csf-report?                             boolean
-    +--ro filter-config-snk*                      mac-address
-    +--ro mac-length?                             uint64
-    +--ro filter-config
-    |  +--ro c-2-00-00-10?    boolean
-    |  +--ro c-2-00-00-00?    boolean
-    |  +--ro c-2-00-00-01?    boolean
-    |  +--ro c-2-00-00-02?    boolean
-    |  +--ro c-2-00-00-03?    boolean
-    |  +--ro c-2-00-00-04?    boolean
-    |  +--ro c-2-00-00-05?    boolean
-    |  +--ro c-2-00-00-06?    boolean
-    |  +--ro c-2-00-00-07?    boolean
-    |  +--ro c-2-00-00-08?    boolean
-    |  +--ro c-2-00-00-09?    boolean
-    |  +--ro c-2-00-00-0-a?   boolean
-    |  +--ro c-2-00-00-0-b?   boolean
-    |  +--ro c-2-00-00-0-c?   boolean
-    |  +--ro c-2-00-00-0-d?   boolean
-    |  +--ro c-2-00-00-0-e?   boolean
-    |  +--ro c-2-00-00-0-f?   boolean
-    |  +--ro c-2-00-00-20?    boolean
-    |  +--ro c-2-00-00-21?    boolean
-    |  +--ro c-2-00-00-22?    boolean
-    |  +--ro c-2-00-00-23?    boolean
-    |  +--ro c-2-00-00-24?    boolean
-    |  +--ro c-2-00-00-25?    boolean
-    |  +--ro c-2-00-00-26?    boolean
-    |  +--ro c-2-00-00-27?    boolean
-    |  +--ro c-2-00-00-28?    boolean
-    |  +--ro c-2-00-00-29?    boolean
-    |  +--ro c-2-00-00-2-a?   boolean
-    |  +--ro c-2-00-00-2-b?   boolean
-    |  +--ro c-2-00-00-2-c?   boolean
-    |  +--ro c-2-00-00-2-d?   boolean
-    |  +--ro c-2-00-00-2-e?   boolean
-    |  +--ro c-2-00-00-2-f?   boolean
-    +--ro is-ssf-reported?                        boolean
-    +--ro pll-thr?                                uint64
-    +--ro actor-oper-key?                         uint64
-    +--ro actor-system-id?                        mac-address
-    +--ro actor-system-priority?                  uint64
-    +--ro collector-max-delay?                    uint64
-    +--ro data-rate?                              uint64
-    +--ro partner-oper-key?                       uint64
-    +--ro partner-system-id?                      mac-address
-    +--ro partner-system-priority?                uint64
-    +--ro csf-config?                             csf-config
-    +--ro prio-config-list*
-    |  +--ro priority?   uint64
-    |  +--ro queue-id?   uint64
-    +--ro queue-config-list*
-    |  +--ro queue-id?          uint64
-    |  +--ro queue-depth?       uint64
-    |  +--ro queue-threshold?   uint64
-    +--ro sched-config?                           scheduling-configuration
-    +--ro codirectional?                          boolean
-    +--ro prio-config-list-1*
-    |  +--ro priority?   uint64
-    |  +--ro queue-id?   uint64
-    +--ro cond-config-list*
-    |  +--ro cir?             uint64
-    |  +--ro cbs?             uint64
-    |  +--ro eir?             uint64
-    |  +--ro ebs?             uint64
-    |  +--ro coupling-flag?   boolean
-    |  +--ro colour-mode?     colour-mode
-    |  +--ro queue-id?        uint64
-    +--ro codirectional-1?                        boolean
+    +--ro eth-term
+    |  +--ro priority-regenerate
+    |  |  +--ro priority-0?   uint64
+    |  |  +--ro priority-1?   uint64
+    |  |  +--ro priority-2?   uint64
+    |  |  +--ro priority-3?   uint64
+    |  |  +--ro priority-4?   uint64
+    |  |  +--ro priority-5?   uint64
+    |  |  +--ro priority-6?   uint64
+    |  |  +--ro priority-7?   uint64
+    |  +--ro ether-type?                   vlan-type
+    |  +--ro filter-config-1*              mac-address
+    |  +--ro frametype-config?             frame-type
+    |  +--ro port-vid?                     vid
+    |  +--ro priority-code-point-config?   pcp-coding
+    +--ro eth-ctp
+       +--ro auxiliary-function-position-sequence*   uint64
+       +--ro vlan-config?                            uint64
+       +--ro csf-rdi-fdi-enable?                     boolean
+       +--ro csf-report?                             boolean
+       +--ro filter-config-snk*                      mac-address
+       +--ro mac-length?                             uint64
+       +--ro filter-config
+       |  +--ro c-2-00-00-10?    boolean
+       |  +--ro c-2-00-00-00?    boolean
+       |  +--ro c-2-00-00-01?    boolean
+       |  +--ro c-2-00-00-02?    boolean
+       |  +--ro c-2-00-00-03?    boolean
+       |  +--ro c-2-00-00-04?    boolean
+       |  +--ro c-2-00-00-05?    boolean
+       |  +--ro c-2-00-00-06?    boolean
+       |  +--ro c-2-00-00-07?    boolean
+       |  +--ro c-2-00-00-08?    boolean
+       |  +--ro c-2-00-00-09?    boolean
+       |  +--ro c-2-00-00-0-a?   boolean
+       |  +--ro c-2-00-00-0-b?   boolean
+       |  +--ro c-2-00-00-0-c?   boolean
+       |  +--ro c-2-00-00-0-d?   boolean
+       |  +--ro c-2-00-00-0-e?   boolean
+       |  +--ro c-2-00-00-0-f?   boolean
+       |  +--ro c-2-00-00-20?    boolean
+       |  +--ro c-2-00-00-21?    boolean
+       |  +--ro c-2-00-00-22?    boolean
+       |  +--ro c-2-00-00-23?    boolean
+       |  +--ro c-2-00-00-24?    boolean
+       |  +--ro c-2-00-00-25?    boolean
+       |  +--ro c-2-00-00-26?    boolean
+       |  +--ro c-2-00-00-27?    boolean
+       |  +--ro c-2-00-00-28?    boolean
+       |  +--ro c-2-00-00-29?    boolean
+       |  +--ro c-2-00-00-2-a?   boolean
+       |  +--ro c-2-00-00-2-b?   boolean
+       |  +--ro c-2-00-00-2-c?   boolean
+       |  +--ro c-2-00-00-2-d?   boolean
+       |  +--ro c-2-00-00-2-e?   boolean
+       |  +--ro c-2-00-00-2-f?   boolean
+       +--ro is-ssf-reported?                        boolean
+       +--ro pll-thr?                                uint64
+       +--ro actor-oper-key?                         uint64
+       +--ro actor-system-id?                        mac-address
+       +--ro actor-system-priority?                  uint64
+       +--ro collector-max-delay?                    uint64
+       +--ro data-rate?                              uint64
+       +--ro partner-oper-key?                       uint64
+       +--ro partner-system-id?                      mac-address
+       +--ro partner-system-priority?                uint64
+       +--ro csf-config?                             csf-config
+       +--ro traffic-shaping
+       |  +--ro prio-config-list*
+       |  |  +--ro priority?   uint64
+       |  |  +--ro queue-id?   uint64
+       |  +--ro queue-config-list*
+       |  |  +--ro queue-id?          uint64
+       |  |  +--ro queue-depth?       uint64
+       |  |  +--ro queue-threshold?   uint64
+       |  +--ro sched-config?        scheduling-configuration
+       |  +--ro codirectional?       boolean
+       +--ro traffic-conditioning
+          +--ro prio-config-list*
+          |  +--ro priority?   uint64
+          |  +--ro queue-id?   uint64
+          +--ro cond-config-list*
+          |  +--ro cir?             uint64
+          |  +--ro cbs?             uint64
+          |  +--ro eir?             uint64
+          |  +--ro ebs?             uint64
+          |  +--ro coupling-flag?   boolean
+          |  +--ro colour-mode?     colour-mode
+          |  +--ro queue-id?        uint64
+          +--ro codirectional?      boolean

--- a/YANG/tapi-eth.yang
+++ b/YANG/tapi-eth.yang
@@ -151,13 +151,25 @@ module tapi-eth {
                 description "This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.
                     range of type : true, false";
             }
-            uses traffic-shaping-pac;
-            uses traffic-conditioning-pac;
+            container traffic-shaping {
+                uses traffic-shaping-pac;
+                description "none";
+            }
+            container traffic-conditioning {
+                uses traffic-conditioning-pac;
+                description "none";
+            }
             description "none";
         }
         grouping eth-connection-end-point-spec {
-            uses eth-termination-pac;
-            uses eth-ctp-pac;
+            container eth-term {
+                uses eth-termination-pac;
+                description "none";
+            }
+            container eth-ctp {
+                uses eth-ctp-pac;
+                description "none";
+            }
             description "none";
         }
         grouping eth-termination-pac {
@@ -228,7 +240,7 @@ module tapi-eth {
             description "none";
         }
         grouping traffic-conditioning-pac {
-            list prio-config-list-1 {
+            list prio-config-list {
                 config false;
                 uses priority-configuration;
                 description "This attribute indicates the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.";
@@ -245,7 +257,7 @@ module tapi-eth {
                     - Coupling flag (CF): 0 or 1
                     - Color mode (CM): color-blind and color-aware.";
             }
-            leaf codirectional-1 {
+            leaf codirectional {
                 type boolean;
                 config false;
                 description "This attribute indicates the direction of the conditioner. The value of true means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the sink part of the containing CTP. The value of false means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the source part of the containing CTP.";
@@ -280,7 +292,10 @@ module tapi-eth {
                 Basic attribute: codirectional, prioConfigList, queueConfigList, schedConfig";
         }
         grouping eth-node-edge-point-spec {
-            uses ety-termination-pac;
+            container ety-term {
+                uses ety-termination-pac;
+                description "none";
+            }
             description "none";
         }
 

--- a/YANG/tapi-notification.yang
+++ b/YANG/tapi-notification.yang
@@ -306,6 +306,36 @@ module tapi-notification {
                 enum CONNECTION_END_POINT {
                     description "none";
                 }
+                enum MAINTENANCE_ENTITY_GROUP {
+                    description "none";
+                }
+                enum MAINTENANCE_ENTITY {
+                    description "none";
+                }
+                enum MEG_END_POINT {
+                    description "none";
+                }
+                enum MEG_INTERMEDIATE_POINT {
+                    description "none";
+                }
+                enum SWITCH_CONTROL {
+                    description "none";
+                }
+                enum SWITCH {
+                    description "none";
+                }
+                enum ROUTE {
+                    description "none";
+                }
+                enum NODE_RULE_GROUP {
+                    description "none";
+                }
+                enum INTER_RULE_GROUP {
+                    description "none";
+                }
+                enum RULE {
+                    description "none";
+                }
             }
             description "The list of TAPI Global Object Class types on which Notifications can be raised.";
         }

--- a/YANG/tapi-odu.tree
+++ b/YANG/tapi-odu.tree
@@ -1,65 +1,79 @@
 module: tapi-odu
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
-    +--ro client-capacity?        uint64
-    +--ro max-client-instances?   uint64
-    +--ro max-client-size?        uint64
+    +--ro odu-pool
+       +--ro client-capacity?        uint64
+       +--ro max-client-instances?   uint64
+       +--ro max-client-size?        uint64
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
-    +--ro odu-type?                  odu-type
-    +--ro odu-rate?                  uint64
-    +--ro odu-rate-tolerance?        uint64
-    +--ro opu-tributary-slot-size?   odu-slot-size
-    +--ro auto-payload-type?         boolean
-    +--ro configured-client-type?    string
-    +--ro configured-mapping-type?   mapping-type
-    +--ro accepted-payload-type
-    |  +--ro named-payload-type?   odu-named-payload-type
-    |  +--ro hex-payload-type?     uint64
-    +--ro tributary-slot-list*       uint64
-    +--ro tributary-port-number?     uint64
-    +--ro accepted-msi?              string
-    +--ro aps-enable?                boolean
-    +--ro aps-level?                 uint64
+    +--ro odu-common
+    |  +--ro odu-type?             odu-type
+    |  +--ro odu-rate?             uint64
+    |  +--ro odu-rate-tolerance?   uint64
+    +--ro odu-term-and-adapter
+    |  +--ro opu-tributary-slot-size?   odu-slot-size
+    |  +--ro auto-payload-type?         boolean
+    |  +--ro configured-client-type?    string
+    |  +--ro configured-mapping-type?   mapping-type
+    |  +--ro accepted-payload-type
+    |     +--ro named-payload-type?   odu-named-payload-type
+    |     +--ro hex-payload-type?     uint64
+    +--ro odu-ctp
+    |  +--ro tributary-slot-list*     uint64
+    |  +--ro tributary-port-number?   uint64
+    |  +--ro accepted-msi?            string
+    +--ro odu-protection
+       +--ro aps-enable?   boolean
+       +--ro aps-level?    uint64
   augment /tapi-common:context/tapi-oam:meg/tapi-oam:mep:
-    +--ro odu-type?                  odu-type
-    +--ro odu-rate?                  uint64
-    +--ro odu-rate-tolerance?        uint64
-    +--ro opu-tributary-slot-size?   odu-slot-size
-    +--ro auto-payload-type?         boolean
-    +--ro configured-client-type?    string
-    +--ro configured-mapping-type?   mapping-type
-    +--ro accepted-payload-type
-    |  +--ro named-payload-type?   odu-named-payload-type
-    |  +--ro hex-payload-type?     uint64
-    +--ro tributary-slot-list*       uint64
-    +--ro tributary-port-number?     uint64
-    +--ro accepted-msi?              string
-    +--ro aps-enable?                boolean
-    +--ro aps-level?                 uint64
+    +--ro odu-common
+    |  +--ro odu-type?             odu-type
+    |  +--ro odu-rate?             uint64
+    |  +--ro odu-rate-tolerance?   uint64
+    +--ro odu-term-and-adapter
+    |  +--ro opu-tributary-slot-size?   odu-slot-size
+    |  +--ro auto-payload-type?         boolean
+    |  +--ro configured-client-type?    string
+    |  +--ro configured-mapping-type?   mapping-type
+    |  +--ro accepted-payload-type
+    |     +--ro named-payload-type?   odu-named-payload-type
+    |     +--ro hex-payload-type?     uint64
+    +--ro odu-ctp
+    |  +--ro tributary-slot-list*     uint64
+    |  +--ro tributary-port-number?   uint64
+    |  +--ro accepted-msi?            string
+    +--ro odu-protection
+       +--ro aps-enable?   boolean
+       +--ro aps-level?    uint64
   augment /tapi-common:context/tapi-oam:meg/tapi-oam:mip:
-    +--ro acti?                string
-    +--ro ex-dapi?             string
-    +--ro ex-sapi?             string
-    +--ro tim-act-disabled?    boolean
-    +--ro tim-det-mode?        tim-det-mo
-    +--ro deg-m?               uint64
-    +--ro deg-thr
-    |  +--ro deg-thr-value?            uint64
-    |  +--ro deg-thr-type?             deg-thr-type
-    |  +--ro percentage-granularity?   percentage-granularity
-    +--ro tcm-fields-in-use*   uint64
-    +--ro tcm-field?           uint64
-    +--ro n-bbe?               uint64
-    +--ro f-bbe?               uint64
-    +--ro n-ses?               uint64
-    +--ro f-ses?               uint64
-    +--ro uas
-    |  +--ro bidirectional?   boolean
-    |  +--ro uas?             uint64
-    |  +--ro nuas?            uint64
-    |  +--ro fuas?            uint64
-    +--ro bdi?                 boolean
-    +--ro deg?                 boolean
-    +--ro lck?                 boolean
-    +--ro oci?                 boolean
-    +--ro ssf?                 boolean
-    +--ro tim?                 boolean
+    +--ro odu-mip
+    |  +--ro acti?               string
+    |  +--ro ex-dapi?            string
+    |  +--ro ex-sapi?            string
+    |  +--ro tim-act-disabled?   boolean
+    |  +--ro tim-det-mode?       tim-det-mo
+    |  +--ro deg-m?              uint64
+    |  +--ro deg-thr
+    |     +--ro deg-thr-value?            uint64
+    |     +--ro deg-thr-type?             deg-thr-type
+    |     +--ro percentage-granularity?   percentage-granularity
+    +--ro odu-ncm
+    |  +--ro tcm-fields-in-use*   uint64
+    +--ro odu-tcm
+    |  +--ro tcm-field?   uint64
+    +--ro odu-pm
+    |  +--ro n-bbe?   uint64
+    |  +--ro f-bbe?   uint64
+    |  +--ro n-ses?   uint64
+    |  +--ro f-ses?   uint64
+    |  +--ro uas
+    |     +--ro bidirectional?   boolean
+    |     +--ro uas?             uint64
+    |     +--ro nuas?            uint64
+    |     +--ro fuas?            uint64
+    +--ro odu-defect
+       +--ro bdi?   boolean
+       +--ro deg?   boolean
+       +--ro lck?   boolean
+       +--ro oci?   boolean
+       +--ro ssf?   boolean
+       +--ro tim?   boolean

--- a/YANG/tapi-odu.yang
+++ b/YANG/tapi-odu.yang
@@ -83,10 +83,25 @@ module tapi-odu {
                 It is present only if the CEP contains a TTP";
         }
         grouping odu-connection-end-point-spec {
-            uses odu-common-pac;
-            uses odu-termination-and-client-adaptation-pac;
-            uses odu-ctp-pac;
-            uses odu-protection-pac;
+            container odu-common {
+                uses odu-common-pac;
+                description "none";
+            }
+            container odu-term-and-adapter {
+                config false;
+                uses odu-termination-and-client-adaptation-pac;
+                description "none";
+            }
+            container odu-ctp {
+                config false;
+                uses odu-ctp-pac;
+                description "none";
+            }
+            container odu-protection {
+                config false;
+                uses odu-protection-pac;
+                description "none";
+            }
             description "none";
         }
         grouping odu-pool-pac {
@@ -107,7 +122,11 @@ module tapi-odu {
             description "none";
         }
         grouping odu-node-edge-point-spec {
-            uses odu-pool-pac;
+            container odu-pool {
+                config false;
+                uses odu-pool-pac;
+                description "none";
+            }
             description "none";
         }
         grouping odu-ctp-pac {
@@ -140,11 +159,28 @@ module tapi-odu {
                 It is present only if the CEP contains a CTP";
         }
         grouping odu-mep-spec {
-            uses odu-mep-pac;
-            uses odu-ncm-pac;
-            uses odu-tcm-mep-pac;
-            uses odu-defect-pac;
-            uses odu-pm-pac;
+            container odu-mep {
+                uses odu-mep-pac;
+                description "none";
+            }
+            container odu-ncm {
+                config false;
+                uses odu-ncm-pac;
+                description "none";
+            }
+            container odu-tcm {
+                config false;
+                uses odu-tcm-mep-pac;
+                description "none";
+            }
+            container odu-defect {
+                uses odu-defect-pac;
+                description "none";
+            }
+            container odu-pm {
+                uses odu-pm-pac;
+                description "none";
+            }
             description "none";
         }
         grouping odu-protection-pac {
@@ -203,11 +239,29 @@ module tapi-odu {
             description "none";
         }
         grouping odu-mip-spec {
-            uses odu-mip-pac;
-            uses odu-ncm-pac;
-            uses odu-tcm-mip-pac;
-            uses odu-pm-pac;
-            uses odu-defect-pac;
+            container odu-mip {
+                config false;
+                uses odu-mip-pac;
+                description "none";
+            }
+            container odu-ncm {
+                config false;
+                uses odu-ncm-pac;
+                description "none";
+            }
+            container odu-tcm {
+                config false;
+                uses odu-tcm-mip-pac;
+                description "none";
+            }
+            container odu-pm {
+                uses odu-pm-pac;
+                description "none";
+            }
+            container odu-defect {
+                uses odu-defect-pac;
+                description "none";
+            }
             description "none";
         }
         grouping odu-mip-pac {

--- a/YANG/tapi-otsi.tree
+++ b/YANG/tapi-otsi.tree
@@ -1,39 +1,43 @@
 module: tapi-otsi
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
-    +--ro selected-nominal-central-frequency*
-    |  +--ro grid-type?                grid-type
-    |  +--ro adjustment-granularity?   adjustment-granularity
-    |  +--ro channel-number?           uint64
-    +--ro supportable-lower-nominal-central-frequency*
-    |  +--ro grid-type?                grid-type
-    |  +--ro adjustment-granularity?   adjustment-granularity
-    |  +--ro channel-number?           uint64
-    +--ro supportable-upper-nominal-central-frequency*
-    |  +--ro grid-type?                grid-type
-    |  +--ro adjustment-granularity?   adjustment-granularity
-    |  +--ro channel-number?           uint64
-    +--ro selected-application-identifier*
-    |  +--ro application-identifier-type?    application-identifier-type
-    |  +--ro application-identifier-value?   string
-    +--ro supportable-application-identifier*
-    |  +--ro application-identifier-type?    application-identifier-type
-    |  +--ro application-identifier-value?   string
-    +--ro selected-frequency-slot*
-       +--ro nominal-central-frequency
-       |  +--ro grid-type?                grid-type
-       |  +--ro adjustment-granularity?   adjustment-granularity
-       |  +--ro channel-number?           uint64
-       +--ro slot-width-number?           uint64
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
-    +--ro available-frequency-slot*
-    |  +--ro nominal-central-frequency
+    +--ro otsi-adapter
+    +--ro otsi-termination
+    |  +--ro selected-nominal-central-frequency*
     |  |  +--ro grid-type?                grid-type
     |  |  +--ro adjustment-granularity?   adjustment-granularity
     |  |  +--ro channel-number?           uint64
-    |  +--ro slot-width-number?           uint64
-    +--ro occupied-frequency-slot*
-       +--ro nominal-central-frequency
-       |  +--ro grid-type?                grid-type
-       |  +--ro adjustment-granularity?   adjustment-granularity
-       |  +--ro channel-number?           uint64
-       +--ro slot-width-number?           uint64
+    |  +--ro supportable-lower-nominal-central-frequency*
+    |  |  +--ro grid-type?                grid-type
+    |  |  +--ro adjustment-granularity?   adjustment-granularity
+    |  |  +--ro channel-number?           uint64
+    |  +--ro supportable-upper-nominal-central-frequency*
+    |  |  +--ro grid-type?                grid-type
+    |  |  +--ro adjustment-granularity?   adjustment-granularity
+    |  |  +--ro channel-number?           uint64
+    |  +--ro selected-application-identifier*
+    |  |  +--ro application-identifier-type?    application-identifier-type
+    |  |  +--ro application-identifier-value?   string
+    |  +--ro supportable-application-identifier*
+    |     +--ro application-identifier-type?    application-identifier-type
+    |     +--ro application-identifier-value?   string
+    +--ro otsi-ctp
+       +--ro selected-frequency-slot*
+          +--ro nominal-central-frequency
+          |  +--ro grid-type?                grid-type
+          |  +--ro adjustment-granularity?   adjustment-granularity
+          |  +--ro channel-number?           uint64
+          +--ro slot-width-number?           uint64
+  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
+    +--ro otsi-pool
+       +--ro available-frequency-slot*
+       |  +--ro nominal-central-frequency
+       |  |  +--ro grid-type?                grid-type
+       |  |  +--ro adjustment-granularity?   adjustment-granularity
+       |  |  +--ro channel-number?           uint64
+       |  +--ro slot-width-number?           uint64
+       +--ro occupied-frequency-slot*
+          +--ro nominal-central-frequency
+          |  +--ro grid-type?                grid-type
+          |  +--ro adjustment-granularity?   adjustment-granularity
+          |  +--ro channel-number?           uint64
+          +--ro slot-width-number?           uint64

--- a/YANG/tapi-otsi.yang
+++ b/YANG/tapi-otsi.yang
@@ -40,13 +40,25 @@ module tapi-otsi {
     /***********************
     * package object-classes
     **********************/ 
-        grouping otsi-a-client-adaptation-pac {
+        grouping otsi-client-adaptation-pac {
             description "none";
         }
         grouping otsi-connection-end-point-spec {
-            uses otsi-a-client-adaptation-pac;
-            uses otsi-termination-pac;
-            uses otsi-g-ctp-pac;
+            container otsi-adapter {
+                config false;
+                uses otsi-client-adaptation-pac;
+                description "none";
+            }
+            container otsi-termination {
+                config false;
+                uses otsi-termination-pac;
+                description "none";
+            }
+            container otsi-ctp {
+                config false;
+                uses otsi-ctp-pac;
+                description "none";
+            }
             description "none";
         }
         grouping otsi-termination-pac {
@@ -79,7 +91,7 @@ module tapi-otsi {
             }
             description "none";
         }
-        grouping otsi-a-pool-pac {
+        grouping otsi-pool-pac {
             list available-frequency-slot {
                 config false;
                 uses frequency-slot;
@@ -93,7 +105,11 @@ module tapi-otsi {
             description "none";
         }
         grouping otsi-node-edge-point-spec {
-            uses otsi-a-pool-pac;
+            container otsi-pool {
+                config false;
+                uses otsi-pool-pac;
+                description "none";
+            }
             description "none";
         }
         grouping otsi-routing-spec {
@@ -103,7 +119,7 @@ module tapi-otsi {
             }
             description "none";
         }
-        grouping otsi-g-ctp-pac {
+        grouping otsi-ctp-pac {
             list selected-frequency-slot {
                 config false;
                 uses frequency-slot;

--- a/YANG/tapi-topology.tree
+++ b/YANG/tapi-topology.tree
@@ -23,6 +23,46 @@ module: tapi-topology
        |  |  +--ro lifecycle-state?                  lifecycle-state
        |  |  +--ro termination-direction?            termination-direction
        |  |  +--ro termination-state?                termination-state
+       |  |  +--ro total-potential-capacity
+       |  |  |  +--ro total-size
+       |  |  |  |  +--ro value?   uint64
+       |  |  |  |  +--ro unit?    capacity-unit
+       |  |  |  +--ro bandwidth-profile
+       |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
+       |  |  |     +--ro committed-information-rate
+       |  |  |     |  +--ro value?   uint64
+       |  |  |     |  +--ro unit?    capacity-unit
+       |  |  |     +--ro committed-burst-size
+       |  |  |     |  +--ro value?   uint64
+       |  |  |     |  +--ro unit?    capacity-unit
+       |  |  |     +--ro peak-information-rate
+       |  |  |     |  +--ro value?   uint64
+       |  |  |     |  +--ro unit?    capacity-unit
+       |  |  |     +--ro peak-burst-size
+       |  |  |     |  +--ro value?   uint64
+       |  |  |     |  +--ro unit?    capacity-unit
+       |  |  |     +--ro color-aware?                  boolean
+       |  |  |     +--ro coupling-flag?                boolean
+       |  |  +--ro available-capacity
+       |  |     +--ro total-size
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro bandwidth-profile
+       |  |        +--ro bw-profile-type?              bandwidth-profile-type
+       |  |        +--ro committed-information-rate
+       |  |        |  +--ro value?   uint64
+       |  |        |  +--ro unit?    capacity-unit
+       |  |        +--ro committed-burst-size
+       |  |        |  +--ro value?   uint64
+       |  |        |  +--ro unit?    capacity-unit
+       |  |        +--ro peak-information-rate
+       |  |        |  +--ro value?   uint64
+       |  |        |  +--ro unit?    capacity-unit
+       |  |        +--ro peak-burst-size
+       |  |        |  +--ro value?   uint64
+       |  |        |  +--ro unit?    capacity-unit
+       |  |        +--ro color-aware?                  boolean
+       |  |        +--ro coupling-flag?                boolean
        |  +--ro aggregated-node-edge-point*                -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
        |  +--ro node-rule-group* [uuid]
        |  |  +--ro rule* [local-id]
@@ -330,6 +370,46 @@ module: tapi-topology
     |        |  |  +--ro lifecycle-state?                  lifecycle-state
     |        |  |  +--ro termination-direction?            termination-direction
     |        |  |  +--ro termination-state?                termination-state
+    |        |  |  +--ro total-potential-capacity
+    |        |  |  |  +--ro total-size
+    |        |  |  |  |  +--ro value?   uint64
+    |        |  |  |  |  +--ro unit?    capacity-unit
+    |        |  |  |  +--ro bandwidth-profile
+    |        |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |  |  |     +--ro committed-information-rate
+    |        |  |  |     |  +--ro value?   uint64
+    |        |  |  |     |  +--ro unit?    capacity-unit
+    |        |  |  |     +--ro committed-burst-size
+    |        |  |  |     |  +--ro value?   uint64
+    |        |  |  |     |  +--ro unit?    capacity-unit
+    |        |  |  |     +--ro peak-information-rate
+    |        |  |  |     |  +--ro value?   uint64
+    |        |  |  |     |  +--ro unit?    capacity-unit
+    |        |  |  |     +--ro peak-burst-size
+    |        |  |  |     |  +--ro value?   uint64
+    |        |  |  |     |  +--ro unit?    capacity-unit
+    |        |  |  |     +--ro color-aware?                  boolean
+    |        |  |  |     +--ro coupling-flag?                boolean
+    |        |  |  +--ro available-capacity
+    |        |  |     +--ro total-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro bandwidth-profile
+    |        |  |        +--ro bw-profile-type?              bandwidth-profile-type
+    |        |  |        +--ro committed-information-rate
+    |        |  |        |  +--ro value?   uint64
+    |        |  |        |  +--ro unit?    capacity-unit
+    |        |  |        +--ro committed-burst-size
+    |        |  |        |  +--ro value?   uint64
+    |        |  |        |  +--ro unit?    capacity-unit
+    |        |  |        +--ro peak-information-rate
+    |        |  |        |  +--ro value?   uint64
+    |        |  |        |  +--ro unit?    capacity-unit
+    |        |  |        +--ro peak-burst-size
+    |        |  |        |  +--ro value?   uint64
+    |        |  |        |  +--ro unit?    capacity-unit
+    |        |  |        +--ro color-aware?                  boolean
+    |        |  |        +--ro coupling-flag?                boolean
     |        |  +--ro aggregated-node-edge-point*                -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
     |        |  +--ro node-rule-group* [uuid]
     |        |  |  +--ro rule* [local-id]
@@ -635,6 +715,46 @@ module: tapi-topology
     |        |  +--ro lifecycle-state?                  lifecycle-state
     |        |  +--ro termination-direction?            termination-direction
     |        |  +--ro termination-state?                termination-state
+    |        |  +--ro total-potential-capacity
+    |        |  |  +--ro total-size
+    |        |  |  |  +--ro value?   uint64
+    |        |  |  |  +--ro unit?    capacity-unit
+    |        |  |  +--ro bandwidth-profile
+    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro committed-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-information-rate
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
+    |        |  +--ro available-capacity
+    |        |     +--ro total-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro bandwidth-profile
+    |        |        +--ro bw-profile-type?              bandwidth-profile-type
+    |        |        +--ro committed-information-rate
+    |        |        |  +--ro value?   uint64
+    |        |        |  +--ro unit?    capacity-unit
+    |        |        +--ro committed-burst-size
+    |        |        |  +--ro value?   uint64
+    |        |        |  +--ro unit?    capacity-unit
+    |        |        +--ro peak-information-rate
+    |        |        |  +--ro value?   uint64
+    |        |        |  +--ro unit?    capacity-unit
+    |        |        +--ro peak-burst-size
+    |        |        |  +--ro value?   uint64
+    |        |        |  +--ro unit?    capacity-unit
+    |        |        +--ro color-aware?                  boolean
+    |        |        +--ro coupling-flag?                boolean
     |        +--ro aggregated-node-edge-point*                -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
     |        +--ro node-rule-group* [uuid]
     |        |  +--ro rule* [local-id]
@@ -857,6 +977,46 @@ module: tapi-topology
     |        +--ro lifecycle-state?                  lifecycle-state
     |        +--ro termination-direction?            termination-direction
     |        +--ro termination-state?                termination-state
+    |        +--ro total-potential-capacity
+    |        |  +--ro total-size
+    |        |  |  +--ro value?   uint64
+    |        |  |  +--ro unit?    capacity-unit
+    |        |  +--ro bandwidth-profile
+    |        |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |     +--ro committed-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro committed-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro color-aware?                  boolean
+    |        |     +--ro coupling-flag?                boolean
+    |        +--ro available-capacity
+    |           +--ro total-size
+    |           |  +--ro value?   uint64
+    |           |  +--ro unit?    capacity-unit
+    |           +--ro bandwidth-profile
+    |              +--ro bw-profile-type?              bandwidth-profile-type
+    |              +--ro committed-information-rate
+    |              |  +--ro value?   uint64
+    |              |  +--ro unit?    capacity-unit
+    |              +--ro committed-burst-size
+    |              |  +--ro value?   uint64
+    |              |  +--ro unit?    capacity-unit
+    |              +--ro peak-information-rate
+    |              |  +--ro value?   uint64
+    |              |  +--ro unit?    capacity-unit
+    |              +--ro peak-burst-size
+    |              |  +--ro value?   uint64
+    |              |  +--ro unit?    capacity-unit
+    |              +--ro color-aware?                  boolean
+    |              +--ro coupling-flag?                boolean
     +---x get-link-details
     |  +---w input
     |  |  +---w topology-id-or-name?   string
@@ -959,6 +1119,46 @@ module: tapi-topology
              |  |  +--ro lifecycle-state?                  lifecycle-state
              |  |  +--ro termination-direction?            termination-direction
              |  |  +--ro termination-state?                termination-state
+             |  |  +--ro total-potential-capacity
+             |  |  |  +--ro total-size
+             |  |  |  |  +--ro value?   uint64
+             |  |  |  |  +--ro unit?    capacity-unit
+             |  |  |  +--ro bandwidth-profile
+             |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
+             |  |  |     +--ro committed-information-rate
+             |  |  |     |  +--ro value?   uint64
+             |  |  |     |  +--ro unit?    capacity-unit
+             |  |  |     +--ro committed-burst-size
+             |  |  |     |  +--ro value?   uint64
+             |  |  |     |  +--ro unit?    capacity-unit
+             |  |  |     +--ro peak-information-rate
+             |  |  |     |  +--ro value?   uint64
+             |  |  |     |  +--ro unit?    capacity-unit
+             |  |  |     +--ro peak-burst-size
+             |  |  |     |  +--ro value?   uint64
+             |  |  |     |  +--ro unit?    capacity-unit
+             |  |  |     +--ro color-aware?                  boolean
+             |  |  |     +--ro coupling-flag?                boolean
+             |  |  +--ro available-capacity
+             |  |     +--ro total-size
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro bandwidth-profile
+             |  |        +--ro bw-profile-type?              bandwidth-profile-type
+             |  |        +--ro committed-information-rate
+             |  |        |  +--ro value?   uint64
+             |  |        |  +--ro unit?    capacity-unit
+             |  |        +--ro committed-burst-size
+             |  |        |  +--ro value?   uint64
+             |  |        |  +--ro unit?    capacity-unit
+             |  |        +--ro peak-information-rate
+             |  |        |  +--ro value?   uint64
+             |  |        |  +--ro unit?    capacity-unit
+             |  |        +--ro peak-burst-size
+             |  |        |  +--ro value?   uint64
+             |  |        |  +--ro unit?    capacity-unit
+             |  |        +--ro color-aware?                  boolean
+             |  |        +--ro coupling-flag?                boolean
              |  +--ro aggregated-node-edge-point*                -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
              |  +--ro node-rule-group* [uuid]
              |  |  +--ro rule* [local-id]

--- a/YANG/tapi-topology.yang
+++ b/YANG/tapi-topology.yang
@@ -160,6 +160,7 @@ module tapi-topology {
                 type leafref {
                     path '/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid';
                 }
+                config false;
                 description "NodeEdgePoint mapped to more than ServiceInterfacePoint (slicing/virtualizing) or a ServiceInterfacePoint mapped to more than one NodeEdgePoint (load balancing/Resilience) should be considered experimental";
             }
             leaf link-port-direction {
@@ -175,6 +176,7 @@ module tapi-topology {
             uses tapi-common:resource-spec;
             uses tapi-common:admin-state-pac;
             uses tapi-common:termination-pac;
+            uses tapi-common:capacity-pac;
             description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
                 The structure of LTP supports all transport protocols including circuit and packet forms.";
         }


### PR DESCRIPTION
Includes the following fixes:
- Renamed Context class/grouping to TapiContext to avoid yang name-clash
- Fixed ConnectivityConstraints & CSEP attributes to be configurable
-  Added the DSR to LayerRateName enumeration - this layerRate is needed to describe variable-rate client ports of simple (fixed mapping or single-layer switching) L0 and L1 devices
- Added CapacityPac to the NodeEdgePoint - This information is needed to expose NEP capabilities when modeling fixed-mapping cases in a compact/simplified manner without presence of
Links/TransitionalLinks attached to the NEP
- Updated Notification.ObjectType enum to include additional TAPI2 classes - added following enumeration literals: MEG, ME, MEP, MIP, MeasurementJob, NodeRuleGroup, InterRuleGroup, Rule, SwitchControl, Switch, Route
- Fix: Updated SwitchControl to GlobalClass instead of LocalClass
- Fix: Updated ODU/OTSi/ETH Pac composition to StrictComposite  - the <ExtendedComposite> pattern used in conjunction with <Specification> pattern was causing attribute namespace clash as well as
cardinality issues in the generated swagger output.